### PR TITLE
fix: ベイルアウトしたユニットの視界範囲の敵ユニットが可視状態になる問題の修正

### DIFF
--- a/game_server/rust_app/src/application/game/get_game_state_usecase.rs
+++ b/game_server/rust_app/src/application/game/get_game_state_usecase.rs
@@ -13,7 +13,7 @@ use crate::{
         triggergame_simulator::{
             models::game::game_id::game_id::GameId, repositories::game_repository::GameRepository,
         },
-        unit_management::repositories::unit_repository::UnitRepository,
+        unit_management::{models::unit::Unit, repositories::unit_repository::UnitRepository},
     },
 };
 
@@ -66,14 +66,25 @@ impl GetGameStateUseCase {
             .cloned()
             .partition(|u| u.owner_player_id() != &player_id);
 
+        // 敵ユニット可視性判定用: ベイルアウトしていない味方ユニットのみを使用
+        let active_friend_units: Vec<Unit> = friend_units
+            .iter()
+            .filter(|u| !u.is_bailed_out())
+            .cloned()
+            .collect();
+
         let response = WebSocketResponse::GetGameStateResult {
             game_state: game.game_state().value().clone(),
             current_turn_number: game.current_turn_number().clone(),
             motion_lab_end_time: game.motion_lab_end_time().clone(),
-            enemy_units: EnemyUnitDto::from_units(&enemy_units, &friend_units, game.visibility()),
+            enemy_units: EnemyUnitDto::from_units(
+                &enemy_units,
+                &active_friend_units,
+                game.visibility(),
+            ),
             friend_units: FriendUnitDto::from_units(&friend_units),
             field_steps: game.visibility().field_steps().to_vec(),
-            visibility: game.visibility().calculate_visibility(&friend_units),
+            visibility: game.visibility().calculate_visibility(&active_friend_units),
         };
 
         self.websocket_sender
@@ -82,5 +93,339 @@ impl GetGameStateUseCase {
 
         // println!("Processing turn for game_id: {}", game_id);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::sync::Mutex;
+
+    use crate::{
+        domain::{
+            triggergame_simulator::models::{
+                game::{game::Game, game_state::GameState, motion_lab_end_time::MotionLabEndTime},
+                turn::turn_number::turn_number::TurnNumber,
+            },
+            unit_management::models::unit::{
+                having_trigger_ids::having_trigger_ids::HavingTriggerIds,
+                position::position::Position, trigger_id::trigger_id::TriggerId,
+                unit_type_id::unit_type_id::UnitTypeId,
+            },
+        },
+        infrastructure::dynamodb::test_utils::{
+            create_active_and_bailed_out_unit_pair, create_simple_visibility_from_field_steps,
+        },
+    };
+
+    /// `GetGameStateResult` からテストで必要な項目だけ保持する構造体。
+    #[derive(Clone)]
+    struct CapturedGetGameStateResult {
+        enemy_units: Vec<EnemyUnitDto>,
+        visibility: Vec<Vec<bool>>,
+    }
+
+    struct MockGameRepository {
+        game: Mutex<Option<Game>>,
+    }
+
+    #[async_trait]
+    impl GameRepository for MockGameRepository {
+        async fn save(&self, _game: &Game) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn update(&self, _game: &Game) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn get_game_by_id(&self, _game_id: &GameId) -> Result<Game, String> {
+            self.game
+                .lock()
+                .unwrap()
+                .clone()
+                .ok_or_else(|| "Game not found".to_string())
+        }
+    }
+
+    struct MockUnitRepository {
+        units: Mutex<Vec<Unit>>,
+    }
+
+    #[async_trait]
+    impl UnitRepository for MockUnitRepository {
+        async fn save(&self, _unit: &Unit) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn update(&self, _unit: &Unit) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn update_units(&self, _units: &Vec<Unit>) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn get_game_units(&self, _game_id: &GameId) -> Result<Vec<Unit>, String> {
+            Ok(self.units.lock().unwrap().clone())
+        }
+    }
+
+    struct MockConnectionRepository {
+        connection_id: String,
+    }
+
+    #[async_trait]
+    impl ConnectionRepository for MockConnectionRepository {
+        async fn save(&self, _player_id: &str, _connection_id: &str) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn get_connection_id(&self, _player_id: &str) -> Result<String, String> {
+            Ok(self.connection_id.clone())
+        }
+    }
+
+    struct MockWebSocketSender {
+        sent_connection_ids: Mutex<Vec<String>>,
+        last_get_game_state: Mutex<Option<CapturedGetGameStateResult>>,
+    }
+
+    #[async_trait]
+    impl WebSocketSender for MockWebSocketSender {
+        async fn send_message(
+            &self,
+            connection_id: &str,
+            response: &WebSocketResponse,
+        ) -> Result<(), String> {
+            self.sent_connection_ids
+                .lock()
+                .unwrap()
+                .push(connection_id.to_string());
+
+            if let WebSocketResponse::GetGameStateResult {
+                enemy_units,
+                visibility,
+                ..
+            } = response
+            {
+                self.last_get_game_state
+                    .lock()
+                    .unwrap()
+                    .replace(CapturedGetGameStateResult {
+                        enemy_units: enemy_units.clone(),
+                        visibility: visibility.clone(),
+                    });
+            }
+
+            Ok(())
+        }
+    }
+
+    #[allow(dead_code)]
+    fn setup_mocks(
+        game: Game,
+        units: Vec<Unit>,
+    ) -> (
+        Arc<MockGameRepository>,
+        Arc<MockUnitRepository>,
+        Arc<MockConnectionRepository>,
+        Arc<MockWebSocketSender>,
+    ) {
+        (
+            Arc::new(MockGameRepository {
+                game: Mutex::new(Some(game)),
+            }),
+            Arc::new(MockUnitRepository {
+                units: Mutex::new(units),
+            }),
+            Arc::new(MockConnectionRepository {
+                connection_id: "test-connection-id".to_string(),
+            }),
+            Arc::new(MockWebSocketSender {
+                sent_connection_ids: Mutex::new(Vec::new()),
+                last_get_game_state: Mutex::new(None),
+            }),
+        )
+    }
+
+    /// テスト用に `Game` を再構築する。
+    fn create_test_game(game_id: GameId, player1_id: PlayerId, player2_id: PlayerId) -> Game {
+        let field_steps =
+            crate::domain::triggergame_simulator::models::game::visibility::Visibility::create()
+                .field_steps()
+                .clone();
+        let visibility = create_simple_visibility_from_field_steps(field_steps);
+
+        Game::reconstruct(
+            game_id,
+            GameState::initial(),
+            TurnNumber::initial(),
+            MotionLabEndTime::initial(),
+            player1_id,
+            player2_id,
+            visibility,
+        )
+    }
+
+    /// 位置と所持者を指定してテスト用ユニットを作成する。
+    fn create_unit(
+        game_id: &GameId,
+        owner_id: &PlayerId,
+        col: i32,
+        row: i32,
+        main_trigger_id: &str,
+    ) -> Unit {
+        Unit::create(
+            UnitTypeId::new("unit_type_test".to_string()),
+            game_id.clone(),
+            owner_id.clone(),
+            Position::new(col, row),
+            TriggerId::new(main_trigger_id.to_string()),
+            TriggerId::new("sub_trigger_test".to_string()),
+            HavingTriggerIds::new(vec![TriggerId::new(main_trigger_id.to_string())]),
+            HavingTriggerIds::new(vec![TriggerId::new("sub_trigger_test".to_string())]),
+            100,
+            100,
+            8,
+            10,
+        )
+    }
+
+    /// アクティブな味方ユニットの視界に敵が入る場合、敵DTOが可視状態になることを検証する。
+    #[tokio::test]
+    async fn test_enemy_units_visible_only_from_active_units() {
+        let game_id = GameId::new("550e8400-e29b-41d4-a716-4466554400a1".to_string());
+        let friend_player_id = PlayerId::new("550e8400-e29b-41d4-a716-4466554400f1".to_string());
+        let enemy_player_id = PlayerId::new("550e8400-e29b-41d4-a716-4466554400e1".to_string());
+
+        let game = create_test_game(
+            game_id.clone(),
+            friend_player_id.clone(),
+            enemy_player_id.clone(),
+        );
+
+        let (active_friend, bailed_friend) =
+            create_active_and_bailed_out_unit_pair(game_id.clone(), friend_player_id.clone());
+        // GameConfig は 36x36。enemy_position 反転後に (5,5) へ来るよう (30,30) を配置する。
+        let enemy = create_unit(&game_id, &enemy_player_id, 30, 30, "enemy_main_trigger");
+
+        let units = vec![active_friend, bailed_friend, enemy];
+        let (game_repo, unit_repo, connection_repo, websocket_sender) = setup_mocks(game, units);
+
+        let usecase = GetGameStateUseCase::new(
+            connection_repo.clone(),
+            game_repo.clone(),
+            unit_repo.clone(),
+            websocket_sender.clone(),
+        );
+
+        let result = usecase.execute(game_id, friend_player_id).await;
+        assert!(result.is_ok());
+
+        let captured = websocket_sender
+            .last_get_game_state
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("GetGameStateResult が送信されていません");
+
+        assert_eq!(captured.enemy_units.len(), 1);
+        let enemy_dto = &captured.enemy_units[0];
+        assert_ne!(enemy_dto.unit_type_id, "UNKNOWN");
+        assert_eq!(enemy_dto.position.col(), 30);
+        assert_eq!(enemy_dto.position.row(), 30);
+        assert!(!enemy_dto.is_bailout);
+    }
+
+    /// 味方ユニットが全員ベイルアウト済みのとき、敵が UNKNOWN かつ不可視になることを検証する。
+    #[tokio::test]
+    async fn test_enemy_units_hidden_when_all_viewers_bailout() {
+        let game_id = GameId::new("550e8400-e29b-41d4-a716-4466554400a2".to_string());
+        let friend_player_id = PlayerId::new("550e8400-e29b-41d4-a716-4466554400f2".to_string());
+        let enemy_player_id = PlayerId::new("550e8400-e29b-41d4-a716-4466554400e2".to_string());
+
+        let game = create_test_game(
+            game_id.clone(),
+            friend_player_id.clone(),
+            enemy_player_id.clone(),
+        );
+
+        let (mut friend_a, mut friend_b) =
+            create_active_and_bailed_out_unit_pair(game_id.clone(), friend_player_id.clone());
+        friend_a.bailout();
+        friend_b.bailout();
+
+        let enemy = create_unit(&game_id, &enemy_player_id, 6, 5, "BAGWORM");
+
+        let units = vec![friend_a, friend_b, enemy];
+        let (game_repo, unit_repo, connection_repo, websocket_sender) = setup_mocks(game, units);
+
+        let usecase = GetGameStateUseCase::new(
+            connection_repo.clone(),
+            game_repo.clone(),
+            unit_repo.clone(),
+            websocket_sender.clone(),
+        );
+
+        let result = usecase.execute(game_id, friend_player_id).await;
+        assert!(result.is_ok());
+
+        let captured = websocket_sender
+            .last_get_game_state
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("GetGameStateResult が送信されていません");
+
+        assert_eq!(captured.enemy_units.len(), 1);
+        let enemy_dto = &captured.enemy_units[0];
+        assert_eq!(enemy_dto.unit_type_id, "UNKNOWN");
+        assert_eq!(enemy_dto.position.col(), -1);
+        assert_eq!(enemy_dto.position.row(), -1);
+        assert!(!captured.visibility[5][6]);
+    }
+
+    /// ベイルアウト済み味方ユニットの位置が視界に含まれないことを検証する。
+    #[tokio::test]
+    async fn test_visibility_excludes_bailed_out_units() {
+        let game_id = GameId::new("550e8400-e29b-41d4-a716-4466554400a3".to_string());
+        let friend_player_id = PlayerId::new("550e8400-e29b-41d4-a716-4466554400f3".to_string());
+        let enemy_player_id = PlayerId::new("550e8400-e29b-41d4-a716-4466554400e3".to_string());
+
+        let game = create_test_game(
+            game_id.clone(),
+            friend_player_id.clone(),
+            enemy_player_id.clone(),
+        );
+
+        let active_friend = create_unit(&game_id, &friend_player_id, 1, 1, "friend_main_trigger");
+        let mut bailed_friend =
+            create_unit(&game_id, &friend_player_id, 10, 10, "friend_main_trigger");
+        bailed_friend.bailout();
+
+        let units = vec![active_friend, bailed_friend];
+        let (game_repo, unit_repo, connection_repo, websocket_sender) = setup_mocks(game, units);
+
+        let usecase = GetGameStateUseCase::new(
+            connection_repo.clone(),
+            game_repo.clone(),
+            unit_repo.clone(),
+            websocket_sender.clone(),
+        );
+
+        let result = usecase.execute(game_id, friend_player_id).await;
+        assert!(result.is_ok());
+
+        let captured = websocket_sender
+            .last_get_game_state
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("GetGameStateResult が送信されていません");
+
+        assert!(captured.visibility[1][1]);
+        assert!(!captured.visibility[10][10]);
     }
 }

--- a/game_server/rust_app/src/domain/triggergame_simulator/models/action/action.rs
+++ b/game_server/rust_app/src/domain/triggergame_simulator/models/action/action.rs
@@ -160,8 +160,9 @@ impl Action {
     /// プレイヤーごとに見せるべき情報をフィルタリングする処理
     /// ただし、combatが発生しなかった場合はNoneを返す
     ///
-    /// * player_id: actionを実行したプレイヤーID(攻撃側)
-    /// * units: 防御側ユニット情報
+    /// * player_id: 閲覧プレイヤーID
+    /// * all_units: 行動者特定に使う全ユニット情報
+    /// * viewer_units: 可視性計算に使う、閲覧プレイヤーのアクティブなユニット情報
     /// * visibility: 視界情報
     ///
     /// ユニット表示パターン
@@ -175,17 +176,21 @@ impl Action {
     pub fn to_player_action(
         &mut self,
         player_id: &PlayerId,
-        units: &Vec<Unit>,
+        all_units: &Vec<Unit>,
+        viewer_units: &Vec<Unit>,
         visibility: &Visibility,
     ) {
         // プレイヤーから見て敵のユニットの行動は、位置とトリガーの向き以外は見えないようにする
-        let attack_unit = units.iter().find(|u| u.unit_id() == &self.unit_id).unwrap();
+        let attack_unit = all_units
+            .iter()
+            .find(|u| u.unit_id() == &self.unit_id)
+            .unwrap();
         if attack_unit.owner_player_id() == player_id {
             // 自分のユニットの行動はそのまま返す
             return;
         }
 
-        let visibility_data = visibility.calculate_visibility(units);
+        let visibility_data = visibility.calculate_visibility(viewer_units);
         let action_visible = visibility_data[self.position.get_enemy_position().row() as usize]
             [self.position.get_enemy_position().col() as usize];
         if action_visible {

--- a/game_server/rust_app/src/domain/triggergame_simulator/services/visibility_projection_service.rs
+++ b/game_server/rust_app/src/domain/triggergame_simulator/services/visibility_projection_service.rs
@@ -59,9 +59,11 @@ impl VisibilityProjectionService {
         // - src/domain/triggergame_simulator/models/step/step.rs
         // - Step::to_player_step の `self.actions.iter_mut().for_each(...)` 周辺
 
+        let active_viewer_units = self.collect_active_viewer_units(player_id, units);
+
         // アクションを走査し、プレイヤー視点のフィルタリングを適用する。
         step.actions_mut().iter_mut().for_each(|action| {
-            action.to_player_action(player_id, units, visibility);
+            action.to_player_action(player_id, units, &active_viewer_units, visibility);
         });
     }
 
@@ -85,13 +87,18 @@ impl VisibilityProjectionService {
         // - Step::to_player_step の
         //   `let player_units ... visibility.calculate_visibility(&player_units)` 周辺
 
-        // 所有ユニットを抽出し、プレイヤー向け可視セルを計算する。
-        let player_units: Vec<Unit> = units
+        let active_viewer_units = self.collect_active_viewer_units(player_id, units);
+        visibility.calculate_visibility(&active_viewer_units)
+    }
+
+    /// 閲覧プレイヤーに属するアクティブなユニットのみを抽出する。
+    fn collect_active_viewer_units(&self, player_id: &PlayerId, units: &Vec<Unit>) -> Vec<Unit> {
+        units
             .iter()
             .filter(|u| u.owner_player_id() == player_id)
+            .filter(|u| !u.is_bailout_value().value())
             .cloned()
-            .collect();
-        visibility.calculate_visibility(&player_units)
+            .collect()
     }
 }
 
@@ -99,8 +106,16 @@ impl VisibilityProjectionService {
 mod tests {
     use super::VisibilityProjectionService;
     use crate::domain::player_management::models::player::player_id::player_id::PlayerId;
+    use crate::domain::triggergame_simulator::models::action::{
+        action::Action,
+        action_type::action_type::{ActionType, ActionTypeValue},
+        trigger_azimuth::trigger_azimuth::TriggerAzimuth,
+    };
     use crate::domain::triggergame_simulator::models::game::{
         game_id::game_id::GameId, visibility::Visibility,
+    };
+    use crate::domain::triggergame_simulator::models::step::{
+        step::Step, step_id::step_id::StepId,
     };
     use crate::domain::unit_management::models::unit::{
         having_trigger_ids::having_trigger_ids::HavingTriggerIds, position::position::Position,
@@ -121,6 +136,20 @@ mod tests {
             100,
             8,
             10,
+        )
+    }
+
+    /// Bagworm 装備の敵アクションを生成する。
+    fn create_enemy_action(enemy_unit: &Unit, position: Position) -> Action {
+        Action::create(
+            ActionType::new(ActionTypeValue::Move),
+            enemy_unit.unit_id().clone(),
+            enemy_unit.unit_type_id().clone(),
+            position,
+            TriggerId::new("BAGWORM".to_string()),
+            TriggerId::new("BAGWORM".to_string()),
+            TriggerAzimuth::new(0),
+            TriggerAzimuth::new(0),
         )
     }
 
@@ -174,5 +203,59 @@ mod tests {
             service.calculate_player_visibility_cells(&player_id, &turn2_units, &visibility);
 
         assert_ne!(turn1_map, turn2_map);
+    }
+
+    /// ベイルアウト済みユニットが可視セル計算に寄与しないことを検証する。
+    #[test]
+    fn test_calculate_player_visibility_cells_excludes_bailed_out_units() {
+        let player_id = PlayerId::new("550e8400-e29b-41d4-a716-446655440404".to_string());
+        let mut active_unit = create_unit(&player_id, Position::new(1, 1));
+        let mut bailed_out_unit = create_unit(&player_id, Position::new(10, 10));
+        active_unit.set_position(Position::new(1, 1));
+        bailed_out_unit.bailout();
+
+        let units = vec![active_unit, bailed_out_unit];
+        let visibility = Visibility::create();
+
+        let map = VisibilityProjectionService::new().calculate_player_visibility_cells(
+            &player_id,
+            &units,
+            &visibility,
+        );
+
+        assert!(map[1][1]);
+        assert!(!map[10][10]);
+    }
+
+    /// 全 viewer がベイルアウト済みなら、敵アクションがマスクされることを検証する。
+    #[test]
+    fn test_project_actions_for_player_hides_enemy_action_when_all_viewers_bailout() {
+        let player_id = PlayerId::new("550e8400-e29b-41d4-a716-446655440405".to_string());
+        let enemy_player_id = PlayerId::new("550e8400-e29b-41d4-a716-446655440406".to_string());
+
+        let mut viewer_unit = create_unit(&player_id, Position::new(5, 5));
+        viewer_unit.bailout();
+        let enemy_unit = create_unit(&enemy_player_id, Position::new(30, 30));
+
+        let action = create_enemy_action(&enemy_unit, Position::new(30, 30));
+        let mut step = Step::create(
+            StepId::new("550e8400-e29b-41d4-a716-446655440407".to_string()),
+            vec![action],
+            vec![],
+        );
+        let units = vec![viewer_unit, enemy_unit];
+        let visibility = Visibility::create();
+
+        VisibilityProjectionService::new().project_actions_for_player(
+            &mut step,
+            &player_id,
+            &units,
+            &visibility,
+        );
+
+        let projected_action = &step.actions()[0];
+        assert_eq!(projected_action.unit_type_id().value(), "UNKNOWN");
+        assert_eq!(projected_action.position().col(), -1);
+        assert_eq!(projected_action.position().row(), -1);
     }
 }

--- a/game_server/rust_app/src/infrastructure/dynamodb/test_utils.rs
+++ b/game_server/rust_app/src/infrastructure/dynamodb/test_utils.rs
@@ -1,5 +1,7 @@
 use crate::domain::player_management::models::player::player_id::player_id::PlayerId;
-use crate::domain::triggergame_simulator::models::game::game_id::game_id::GameId;
+use crate::domain::triggergame_simulator::models::game::{
+    game::Game, game_id::game_id::GameId, visibility::Visibility,
+};
 use crate::domain::unit_management::models::unit::trigger_id::trigger_id::TriggerId;
 use crate::domain::unit_management::models::unit::{
     having_trigger_ids::having_trigger_ids::HavingTriggerIds, position::position::Position,
@@ -56,4 +58,90 @@ pub fn create_test_0_action_points_unit() -> Unit {
         8,
         0,
     )
+}
+
+/// アクティブユニットとベイルアウトユニットのペアを作成
+pub fn create_active_and_bailed_out_unit_pair(
+    game_id: GameId,
+    player_id: PlayerId,
+) -> (Unit, Unit) {
+    let active_unit = Unit::create(
+        UnitTypeId::new("unit_type_active".to_string()),
+        game_id.clone(),
+        player_id.clone(),
+        Position::new(5, 5),
+        TriggerId::new("main_trigger_001".to_string()),
+        TriggerId::new("sub_trigger_001".to_string()),
+        HavingTriggerIds::new(vec![TriggerId::new("main_trigger_001".to_string())]),
+        HavingTriggerIds::new(vec![TriggerId::new("sub_trigger_001".to_string())]),
+        100,
+        100,
+        8,
+        10,
+    );
+
+    let mut bailed_out_unit = Unit::create(
+        UnitTypeId::new("unit_type_bailed".to_string()),
+        game_id,
+        player_id,
+        Position::new(10, 10),
+        TriggerId::new("main_trigger_002".to_string()),
+        TriggerId::new("sub_trigger_002".to_string()),
+        HavingTriggerIds::new(vec![TriggerId::new("main_trigger_002".to_string())]),
+        HavingTriggerIds::new(vec![TriggerId::new("sub_trigger_002".to_string())]),
+        100,
+        100,
+        8,
+        10,
+    );
+    bailed_out_unit.bailout();
+
+    (active_unit, bailed_out_unit)
+}
+
+/// field_stepsから簡潔な Visibility インスタンスを作成
+pub fn create_simple_visibility_from_field_steps(field_steps: Vec<Vec<i32>>) -> Visibility {
+    Visibility::new(field_steps)
+}
+
+/// ゲームと指定数のユニットを作成（一部ベイルアウト状態）
+pub fn create_test_game_with_units(
+    game_id: GameId,
+    units_count: usize,
+    bailout_indices: Vec<usize>,
+) -> (Game, Vec<Unit>) {
+    let player1_id = PlayerId::new("550e8400-e29b-41d4-a716-446655440011".to_string());
+    let player2_id = PlayerId::new("550e8400-e29b-41d4-a716-446655440022".to_string());
+    let game = Game::create(game_id.clone(), &player1_id, &player2_id);
+
+    let mut units = Vec::new();
+    for i in 0..units_count {
+        let owner = if i % 2 == 0 {
+            player1_id.clone()
+        } else {
+            player2_id.clone()
+        };
+
+        let mut unit = Unit::create(
+            UnitTypeId::new(format!("unit_type_{}", i)),
+            game_id.clone(),
+            owner,
+            Position::new((5 + i as i32) % 20, (5 + i as i32) % 20),
+            TriggerId::new(format!("main_trigger_{}", i)),
+            TriggerId::new(format!("sub_trigger_{}", i)),
+            HavingTriggerIds::new(vec![TriggerId::new(format!("main_trigger_{}", i))]),
+            HavingTriggerIds::new(vec![TriggerId::new(format!("sub_trigger_{}", i))]),
+            100,
+            100,
+            8,
+            10,
+        );
+
+        if bailout_indices.contains(&i) {
+            unit.bailout();
+        }
+        units.push(unit);
+    }
+
+    (game, units)
 }


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記載 -->

## 関連Issue

- Closes #51 

## 変更内容

- ベイルアウトしたユニット以外のユニットの視界範囲で敵ユニットの可視演算を行う

## 動作確認

### 確認環境

- [x] local
- [ ] dev

### 手順

1. 
2. 
3. 

### 結果

- [x] 期待通りに動作する
- [x] 既存機能へ副作用がないことを確認した

## 影響範囲

- [ ] game-client
- [x] game_server
- [ ] local-websocket-apigateway
- [ ] local-dynamodb-initialize
- [ ] local-eventbridge-scheduler
- [ ] ドキュメントのみ

## テスト

- [ ] 追加/変更した処理に対して必要なテストを実施した
- [ ] 手動確認のみ（理由を下に記載）

手動確認理由（必要時）:

## UI変更（必要時）

- スクリーンショット or 動画を添付

## レビュー観点（任意）

<!-- 特に見てほしい点があれば記載 -->

## チェックリスト

- [x] ブランチ名が規約に沿っている（`feature/*`, `fix/*`, `chore/*`, `docs/*`）
- [x] PRタイトルが規約に沿っている（`<type>: <概要> (#issue番号)`）
- [x] 1PR1目的になっている
- [x] 不要な差分（無関係な整形/リネーム等）がない
- [x] 破壊的変更がある場合、内容と移行手順を記載した

## 備考

上記はあくまで推奨ルールです。従わなくても全然いいですが、迷ったら参考にしてください。
