### PR TITLE
fix: 攻撃ユニット・防御ユニットの敵味方を分岐して座標を反転させる修正

### DIFF
--- a/game-client/game-logics/entities/CharacterImageState.ts
+++ b/game-client/game-logics/entities/CharacterImageState.ts
@@ -56,6 +56,7 @@ export class CharacterImageState {
       action.getPosition().col,
       action.getPosition().row
     );
+    const duration = this.position.col !== 36 ? 750 : 0; // バッグワーム状態なら移動アニメなし
     this.position = action.getPosition(); // キャラクターの座標を更新
     console.log(`キャラクター${this.unitId}の移動先: マス(${action.getPosition().col}, ${action.getPosition().row}) -> ピクセル(${targetPixelPos.x}, ${targetPixelPos.y})`);
     this.setDirection({ main: action.getMainTriggerAzimuth(), sub: action.getSubTriggerAzimuth() });
@@ -64,7 +65,7 @@ export class CharacterImageState {
     this.image.updateUnitImage(action.getUnitTypeId());
     this.image.setVisible(action.getPosition().col !== 36 && action.getPosition().row !== 36); // 座標が範囲外でない場合のみ表示
     // 移動アニメーションを実行
-    this.image.moveUnitTween(targetPixelPos.x, targetPixelPos.y, () => {
+    this.image.moveUnitTween(targetPixelPos.x, targetPixelPos.y, duration, () => {
       // 移動完了後にトリガー表示を更新
       this.updateTriggerPositionsForCharacter(action);
     }, onStepComplete);
@@ -89,28 +90,6 @@ export class CharacterImageState {
     // サブトリガーの表示を更新
     this.subTriggerFan?.updateTriggerAzimuth(action.getSubTriggerAzimuth(), this.image.x, this.image.y, subTriggerStatus.angle, subTriggerStatus.range, subTriggerKey, visible);
   }
-
-  /**
-   * 攻撃を与えた際の攻撃の表示を行う
-   * @param combat - 戦闘情報
-   */
-  executeCharacterAttack(
-    combat: Combat
-  ) {
-    // 攻撃先(防御したユニット)の座標を取得
-    const targetPosition = combat.getDefenderPosition();
-    const invertedTargetPosition = this.hexUtils.invertPosition(targetPosition);
-    const targetPixelPos = this.hexUtils.getHexPosition(invertedTargetPosition.col, invertedTargetPosition.row);
-
-    // 攻撃エフェクトを表示
-    this.image.drawAnimatedArrowBetweenCharacters(
-      {
-        x: targetPixelPos.x,
-        y: targetPixelPos.y,
-      }
-    );
-  }
-
 
   /**
    * 攻撃を受けた際の防御・回避の表示を行う

--- a/game-client/game-logics/models/Combat.ts
+++ b/game-client/game-logics/models/Combat.ts
@@ -57,6 +57,10 @@ export class Combat {
     return this.attackingUnitId;
   }
 
+  getAttackerPosition(): Position {
+    return this.attackerPosition;
+  }
+
   getDefendingUnitId(): string {
     return this.defendingUnitId;
   }

--- a/game-client/game-logics/phaser/game-objects/graphics/AttackArrow.ts
+++ b/game-client/game-logics/phaser/game-objects/graphics/AttackArrow.ts
@@ -1,0 +1,63 @@
+/**
+ * 攻撃矢印を描画するクラス
+ */
+export class AttackArrow extends Phaser.GameObjects.Graphics {
+
+  /**
+   * 攻撃矢印を描画するコンストラクタ
+   * @param scene 
+   * @param x1 
+   * @param y1 
+   * @param x2 
+   * @param y2 
+   */
+  constructor(scene: Phaser.Scene, x1: number, y1: number, x2: number, y2: number) {
+    super(scene);
+    super.lineStyle(4, 0x0091EA);
+    super.fillStyle(0x0091EA);
+
+    const arrowSize = 15; // 矢印の先端の大きさ
+
+    // 線の描画
+    this.beginPath();
+    this.moveTo(x1, y1);
+    this.lineTo(x2, y2);
+    this.stroke();
+    this.setDepth(1); // トリガー扇形より前面に表示
+
+    // 矢印の角度を計算 (ラジアン)
+    const angle = Phaser.Math.Angle.Between(x1, y1, x2, y2);
+
+    // 先端の三角形を描画
+    // 角度から少しずらした3点を計算し、終点に配置
+    this.fillTriangle(
+      x2,
+      y2,
+      x2 - Math.cos(angle - Math.PI / 6) * arrowSize,
+      y2 - Math.sin(angle - Math.PI / 6) * arrowSize,
+      x2 - Math.cos(angle + Math.PI / 6) * arrowSize,
+      y2 - Math.sin(angle + Math.PI / 6) * arrowSize
+    );
+    scene.add.existing(this);
+  }
+
+
+  /**
+   * アニメーション付きの矢印を描画
+   * 描画完了後は自動的に削除される
+   */
+  public drawAnimatedArrow() {
+    this.setAlpha(0);
+    // キャラクターを徐々に透明にして削除
+    this.scene.tweens.add({
+      targets: this,
+      alpha: 1,
+      duration: 250,
+      delay: 0,
+      ease: "Power2",
+      onComplete: () => {
+        this.destroy();
+      },
+    });
+  }
+}

--- a/game-client/game-logics/phaser/game-objects/images/UnitImage.ts
+++ b/game-client/game-logics/phaser/game-objects/images/UnitImage.ts
@@ -40,12 +40,12 @@ export class UnitImage extends Phaser.GameObjects.Image {
   }
 
   /** ユニットを移動させるアニメーション */
-  moveUnitTween(targetX: number, targetY: number, onUpdate: () => void, onComplete: () => void) {
+  moveUnitTween(targetX: number, targetY: number, duration: number = 750, onUpdate: () => void, onComplete: () => void) {
     this.scene.tweens.add({
       targets: this,
       x: targetX,
       y: targetY,
-      duration: 750,
+      duration: duration,
       ease: "Power2",
       onUpdate: onUpdate,
       onComplete: onComplete
@@ -95,79 +95,6 @@ export class UnitImage extends Phaser.GameObjects.Image {
         shieldImage.destroy();
       },
     });
-  }
-
-  /**
-   * アニメーション付きの矢印を描画
-   * @param fromCharacter - 矢印の始点となるキャラクターのImageオブジェクト
-   * @param toCharacter - 矢印の終点となるキャラクターのImageオブジェクト
-   * @param color - 矢印の色（デフォルトは赤色0xff0000）
-   * @returns 描画した矢印のGraphicsオブジェクト
-   */
-  drawAnimatedArrowBetweenCharacters(
-    defenderPos: { x: number; y: number; },
-  ): Phaser.GameObjects.Graphics {
-    const fromX = this.x;
-    const fromY = this.y;
-    const toX = defenderPos.x;
-    const toY = defenderPos.y;
-    const arrowGraphics = this.drawArrow(this.scene, fromX, fromY, toX, toY);
-    arrowGraphics.setAlpha(0);
-
-    // キャラクターを徐々に透明にして削除
-    this.scene.tweens.add({
-      targets: arrowGraphics,
-      alpha: 1,
-      duration: 250,
-      delay: 0,
-      ease: "Power2",
-      onComplete: () => {
-        arrowGraphics.destroy();
-      },
-    });
-    return arrowGraphics;
-  }
-
-
-  /**
-   * 2点間に矢印を描画する関数
-   * @param {Phaser.Scene} scene - シーンオブジェクト
-   * @param {number} x1 - 始点のX座標
-   * @param {number} y1 - 始点のY座標
-   * @param {number} x2 - 終点のX座標
-   * @param {number} y2 - 終点のY座標
-   * @returns {Phaser.GameObjects.Graphics} Graphicsオブジェクト
-   */
-  private drawArrow(scene: Phaser.Scene, x1: number, y1: number, x2: number, y2: number): Phaser.GameObjects.Graphics {
-    const graphics = scene.add.graphics({
-      lineStyle: { width: 4, color: 0x0091EA },
-      fillStyle: { color: 0x0091EA }
-    });
-
-    const arrowSize = 15; // 矢印の先端の大きさ
-
-    // 線の描画
-    graphics.beginPath();
-    graphics.moveTo(x1, y1);
-    graphics.lineTo(x2, y2);
-    graphics.stroke();
-    graphics.setDepth(1); // トリガー扇形より前面に表示
-
-    // 矢印の角度を計算 (ラジアン)
-    const angle = Phaser.Math.Angle.Between(x1, y1, x2, y2);
-
-    // 先端の三角形を描画
-    // 角度から少しずらした3点を計算し、終点に配置
-    graphics.fillTriangle(
-      x2,
-      y2,
-      x2 - Math.cos(angle - Math.PI / 6) * arrowSize,
-      y2 - Math.sin(angle - Math.PI / 6) * arrowSize,
-      x2 - Math.cos(angle + Math.PI / 6) * arrowSize,
-      y2 - Math.sin(angle + Math.PI / 6) * arrowSize
-    );
-
-    return graphics;
   }
 
   /**

--- a/game-client/game-logics/phaser/scenes/GridCellsScene.ts
+++ b/game-client/game-logics/phaser/scenes/GridCellsScene.ts
@@ -340,6 +340,7 @@ export class GridCellsScene extends Phaser.Scene {
   private createTurnReplayControllerDeps(): TurnReplayControllerDeps {
     return {
       scene: this,
+      hexUtils: this.hexUtils,
       characterManager: this.characterManager,
       onReplayCompleted: () => {
         this.handleFinishMotionExecute();

--- a/game-client/game-logics/phaser/scenes/controllers/TurnReplayController.ts
+++ b/game-client/game-logics/phaser/scenes/controllers/TurnReplayController.ts
@@ -1,7 +1,12 @@
 import { CharacterManager } from "@/game-logics/characterManager";
 import { MAX_TURN } from "@/game-logics/config/game-config";
+import { HexUtils } from "@/game-logics/hexUtils";
+import { Combat } from "@/game-logics/models/Combat";
 import { Turn } from "@/game-logics/models/Turn";
 import { GameResult } from "@/types/GameTypes";
+import { AttackArrow } from "../../game-objects/graphics/AttackArrow";
+import { PlayerCharacterState } from "@/game-logics/entities/PlayerCharacterState";
+import { EnemyCharacterState } from "@/game-logics/entities/EnemyCharacterState";
 
 /**
  * TurnReplayController が参照する依存関係。
@@ -11,6 +16,7 @@ import { GameResult } from "@/types/GameTypes";
  */
 export interface TurnReplayControllerDeps {
   scene: Phaser.Scene;
+  hexUtils: HexUtils;
   characterManager: CharacterManager;
   onReplayCompleted: (turnNumber: number) => void;
   clearTriggerArrows?: () => void;
@@ -127,7 +133,7 @@ export class TurnReplayController {
       if (attackingCharacter) {
         // 攻撃側が存在する場合: 攻撃演出を再生する。
         console.log(`--- コンバット ${combatIndex + 1} 開始 ---`);
-        attackingCharacter.executeCharacterAttack(combat);
+        this.replayCharacterAttack(combat);
       }
 
       const defendingCharacter = this.deps.characterManager.findCharacterByUnitId(
@@ -196,6 +202,56 @@ export class TurnReplayController {
           console.warn(`視界の不一致を検出: (${col}, ${row}) - サーバー: ${serverVisibilityMap[row][col]}, クライアント: ${clientVisibilityMap[row][col]}`);
         }
       }
+    }
+  }
+
+  /**
+   * 攻撃を与えた際の攻撃の表示を行う
+   * @param combat - 戦闘情報
+   */
+  private replayCharacterAttack(
+    combat: Combat
+  ) {
+    const attackingCharacter = this.deps.characterManager.findCharacterByUnitId(combat.getAttackingUnitId());
+
+    const drawArrow = (attacker: { x: number; y: number; }, target: { x: number; y: number; }) => {
+      // 攻撃エフェクトを表示
+      const attackArrow = new AttackArrow(
+        this.deps.scene,
+        attacker.x,
+        attacker.y,
+        target.x,
+        target.y
+      );
+      // アニメーション付きの矢印を描画
+      attackArrow.drawAnimatedArrow();
+    };
+
+    if (attackingCharacter instanceof PlayerCharacterState) {
+      // 攻撃元の座標を取得
+      const attackerPosition = combat.getAttackerPosition();
+      const attackerPixelPos = this.deps.hexUtils.getHexPosition(attackerPosition.col, attackerPosition.row);
+
+      // 攻撃先(防御したユニット)の座標を取得
+      const targetPosition = combat.getDefenderPosition();
+      const invertedTargetPosition = this.deps.hexUtils.invertPosition(targetPosition);
+      const targetPixelPos = this.deps.hexUtils.getHexPosition(invertedTargetPosition.col, invertedTargetPosition.row);
+
+      // 攻撃エフェクトを表示
+      drawArrow(attackerPixelPos, targetPixelPos);
+
+    } else if (attackingCharacter instanceof EnemyCharacterState) {
+      // 攻撃元の座標を取得
+      const attackerPosition = combat.getAttackerPosition();
+      const invertedAttackerPosition = this.deps.hexUtils.invertPosition(attackerPosition);
+      const attackerPixelPos = this.deps.hexUtils.getHexPosition(invertedAttackerPosition.col, invertedAttackerPosition.row);
+
+      // 攻撃先(防御したユニット)の座標を取得
+      const targetPosition = combat.getDefenderPosition();
+      const targetPixelPos = this.deps.hexUtils.getHexPosition(targetPosition.col, targetPosition.row);
+
+      // 攻撃エフェクトを表示
+      drawArrow(attackerPixelPos, targetPixelPos);
     }
   }
 }


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記載 -->

## 関連Issue

- Closes #19 

## 変更内容

- 攻撃ユニット・防御ユニットの敵味方を分岐して座標を反転させる
- 攻撃時の矢印をPhserオブジェクト化
- バッグワーム装備者が可視状態になったときは移動のアニメーションなし

## 動作確認

### 確認環境

- [x] local
- [ ] dev

### 手順

1. ゲームを開始する
2. ユニットを移動させつつ戦闘を発生させる
3. ユニットを細かく移動させ矢印の位置を確認する

### 結果

- [x] 期待通りに動作する
- [x] 既存機能へ副作用がないことを確認した

## 影響範囲

- [x] game-client
- [ ] game_server
- [ ] local-websocket-apigateway
- [ ] local-dynamodb-initialize
- [ ] local-eventbridge-scheduler
- [ ] ドキュメントのみ

## テスト

- [ ] 追加/変更した処理に対して必要なテストを実施した
- [x] 手動確認のみ（理由を下に記載）

手動確認理由（必要時）:

## UI変更（必要時）

- スクリーンショット or 動画を添付

## レビュー観点（任意）

<!-- 特に見てほしい点があれば記載 -->

## チェックリスト

- [x] ブランチ名が規約に沿っている（`feature/*`, `fix/*`, `chore/*`, `docs/*`）
- [x] PRタイトルが規約に沿っている（`<type>: <概要> (#issue番号)`）
- [x] 1PR1目的になっている
- [x] 不要な差分（無関係な整形/リネーム等）がない
- [x] 破壊的変更がある場合、内容と移行手順を記載した

## 備考

上記はあくまで推奨ルールです。従わなくても全然いいですが、迷ったら参考にしてください。
