### PR TITLE
fix: ターンのダイアログなどの諸々バグ修正

### DIFF
--- a/game-client/app/game/[gameId]/page.tsx
+++ b/game-client/app/game/[gameId]/page.tsx
@@ -44,24 +44,30 @@ export default function GamePage() {
 
   const checkGameState = (friendUnits: FriendUnit[], enemyUnits: EnemyUnit[], currentTurn: number, gameState?: GameState) => {
     if (isConnected && playerId) {
+      setFriendUnits(friendUnits);
+      setEnemyUnits(enemyUnits);
       const aliveFriendUnits = friendUnits.filter(unit => !unit.isBailout);
       const aliveEnemyUnits = enemyUnits.filter(unit => !unit.isBailout);
       if (aliveFriendUnits.length === 0 && aliveEnemyUnits.length === 0) {
-        resultDialogRef.current?.showModal();
         setGameResult("Draw");
       } else if (aliveFriendUnits.length === 0) {
-        resultDialogRef.current?.showModal();
         setGameResult("Lose");
       } else if (aliveEnemyUnits.length === 0) {
-        resultDialogRef.current?.showModal();
         setGameResult("Win");
       } else if (currentTurn >= MAX_TURN || gameState === "Completed") {
         console.log("最大ターン数に到達: 引き分け");
-        resultDialogRef.current?.showModal();
         setGameResult("Draw");
       }
     }
   };
+
+  useEffect(() => {
+    // ゲーム終了の検知
+    if (gameResult !== "InProgress") {
+      console.log("ゲーム状態が変更されました:", gameResult);
+      resultDialogRef.current?.showModal();
+    }
+  }, [gameResult]);
 
   useEffect(() => {
     /** ゲーム状態の受信処理 */
@@ -86,7 +92,7 @@ export default function GamePage() {
     const handleNotifyGameState = (data: WebSocketResponseType) => {
       if (data.action === "notifyGameState") {
         console.log("ゲーム結果を受信:", data);
-        if (data.state === "Completed") {
+        if (data.state === "Completed" && data.gameId === gameId) {
           // ゲーム終了の通知を受け取った場合、結果を設定してダイアログを表示する
           setGameResult(data.outcome);
           setGameResultMsg(data.message || null);
@@ -132,20 +138,18 @@ export default function GamePage() {
       <RotateView />
 
       <NormalFullDialog ref={resultDialogRef}>
-        {gameResult && gameResult !== "InProgress" && (
-          <BattleResultPanel
-            friendUnits={friendUnits}
-            enemyUnits={enemyUnits}
-            result={gameResult}
-            turn={currentTurn}
-            message={gameResultMsg}
-          />
-        )}
+        <BattleResultPanel
+          friendUnits={friendUnits}
+          enemyUnits={enemyUnits}
+          result={gameResult}
+          turn={currentTurn}
+          message={gameResultMsg}
+        />
       </NormalFullDialog>
       {/* ゲーム画面 */}
       {friendUnits.length > 0 && enemyUnits.length > 0 && gameResult === "InProgress" && (
         <div className="w-full h-full">
-          <GameGrid currentTurn={currentTurn} friendUnits={friendUnits} enemyUnits={enemyUnits} fieldSteps={fieldSteps} visibility={visibility} motionLabEndTime={motionLabEndTime} gameResult={gameResult} setGameResult={setGameResult} checkGameState={checkGameState} />
+          <GameGrid currentTurn={currentTurn} friendUnits={friendUnits} enemyUnits={enemyUnits} fieldSteps={fieldSteps} visibility={visibility} motionLabEndTime={motionLabEndTime} gameResult={gameResult} setGameResult={setGameResult} checkGameState={checkGameState} setCurrentTurn={setCurrentTurn} />
         </div>
       )}
     </div>

--- a/game-client/contexts/types/WebSocketResponses.ts
+++ b/game-client/contexts/types/WebSocketResponses.ts
@@ -34,6 +34,7 @@ export interface GetGameStateResponse {
  */
 export interface NotifyGameStateResponse {
   action: "notifyGameState";
+  gameId: string;
   message: string;
   state: GameState;
   outcome: GameResult;

--- a/game-client/game-logics/GameGrid.tsx
+++ b/game-client/game-logics/GameGrid.tsx
@@ -26,13 +26,14 @@ interface GameGridProps {
   gameResult: GameResult | null;
   setGameResult: (result: GameResult) => void;
   checkGameState: (friendUnits: FriendUnit[], enemyUnits: EnemyUnit[], currentTurn: number) => void;
+  setCurrentTurn: (turn: number) => void;
 }
 
 /**
  * PhaserゲームのReactコンポーネント
  * SSR（Server-Side Rendering）対応のため、動的インポートを使用
  */
-const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnits, fieldSteps, visibility, motionLabEndTime, gameResult, setGameResult, checkGameState }) => {
+const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnits, fieldSteps, visibility, motionLabEndTime, gameResult, setGameResult, checkGameState, setCurrentTurn }) => {
 
   // PhaserゲームインスタンスのRef（型安全性のため動的インポートの型を使用）
   const gameRef = useRef<import("phaser").Game | null>(null);
@@ -44,7 +45,6 @@ const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnit
 
   // ゲームモードの状態管理
   const [gameMode, setGameMode] = useState<"lab" | "execute">("lab");
-  const [currentTurnState, setCurrentTurnState] = useState<number>(currentTurn);
   const [motionLabEndTimeState, setMotionLabEndTimeState] = useState<Date>(motionLabEndTime);
   const [motionExecuteEndTimeState, setMotionExecuteEndTimeState] = useState<Date>(motionLabEndTime);
   const motionLabDialogRef = useRef<MotionLabDialogHandle>(null);
@@ -91,7 +91,7 @@ const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnit
   /** ターン情報の送信 */
   const handleTurnExecution = (steps: Step[]) => {
     console.log("Phaserからターン情報を受け取りました:", steps, isConnected, playerId, gameId);
-    if (isConnected && playerId && gameId) {
+    if (isConnected && playerId && gameId && gameResult === "InProgress") {
       const messageData = {
         action: "turnExecution" as const,
         playerId,
@@ -112,12 +112,11 @@ const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnit
 
   /** ユニットの行動終了処理 */
   const handleFinishMotionExecute = () => {
-    console.log("ユニットの行動終了処理を実行します。,現在のターン状態:", currentTurnState);
-    if (currentTurnState < MAX_TURN) {
+    console.log("ユニットの行動終了処理を実行します。,現在のターン状態:", currentTurn);
+    if (currentTurn < MAX_TURN) {
       // 次のターンの動きの設定フェーズへ移行
       setGameMode("lab");
       motionLabDialogRef.current?.show();
-      setCurrentTurnState((prev => prev + 1));
     }
   };
 
@@ -144,6 +143,7 @@ const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnit
         const hydratedTurn = Turn.fromJSON(data.turn);
         targetScene.executeTurn(hydratedTurn, new Date(data.motionLabEndTime)); // Phaserシーンにターン情報を渡して実行
         setGameMode("execute");
+        setCurrentTurn(data.turn.getTurnNumber());
         motionExecuteDialogRef.current?.show();
         setMotionExecuteEndTimeState(new Date(Date.now() + 15000));
         setMotionLabEndTimeState(new Date(data.motionLabEndTime));
@@ -240,9 +240,9 @@ const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnit
       {/* ゲームモード表示 */}
       <div className="absolute top-2 right-2 p-2 z-50">
         {gameMode === "lab" ? (
-          <TurnStateMotionLabPanel turn={currentTurnState} endtime={motionLabEndTimeState} maxTurn={MAX_TURN} />
+          <TurnStateMotionLabPanel turn={currentTurn} endtime={motionLabEndTimeState} maxTurn={MAX_TURN} />
         ) : (
-          <TurnStateMotionExecutePanel turn={currentTurnState} endtime={motionExecuteEndTimeState} maxTurn={MAX_TURN} />
+          <TurnStateMotionExecutePanel turn={currentTurn} endtime={motionExecuteEndTimeState} maxTurn={MAX_TURN} />
         )}
       </div>
 
@@ -254,8 +254,8 @@ const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnit
       />
 
       {/* 動きの設定とユニットの行動のダイアログ表示 */}
-      <MotionLabDialog ref={motionLabDialogRef} turn={currentTurnState}></MotionLabDialog>
-      <MotionExecuteDialog ref={motionExecuteDialogRef} turn={currentTurnState}></MotionExecuteDialog>
+      <MotionLabDialog ref={motionLabDialogRef} turn={currentTurn}></MotionLabDialog>
+      <MotionExecuteDialog ref={motionExecuteDialogRef} turn={currentTurn}></MotionExecuteDialog>
     </div>
   );
 };

--- a/game-client/game-logics/entities/CharacterImageState.ts
+++ b/game-client/game-logics/entities/CharacterImageState.ts
@@ -102,8 +102,7 @@ export class CharacterImageState {
       // 撃破状態を表示してキャラクターを削除
       this.image.showBailOutAndRemoveCharacter();
       this.isBailedOut = true;
-      this.hideMainTriggerFan();
-      this.hideSubTriggerFan();
+      this.clearTriggerFans();
     } else if (combat.getIsAvoidedCombat()) {
       // 回避状態を表示
       this.image.showAvoidImage();
@@ -129,6 +128,16 @@ export class CharacterImageState {
   /** サブトリガーの表示をオフにする */
   hideSubTriggerFan() {
     this.subTriggerFan?.setTriggerVisible(false);
+  }
+
+  /** ベイルアウト時にトリガー表示をクリアする */
+  clearTriggerFans() {
+    this.mainTriggerFan?.setTriggerVisible(false);
+    this.mainTriggerFan?.destroy();
+    this.mainTriggerFan = null;
+    this.subTriggerFan?.setTriggerVisible(false);
+    this.subTriggerFan?.destroy();
+    this.subTriggerFan = null;
   }
 
   // ゲッター

--- a/game_server/rust_app/src/application/schedule/motion_lab_limit_usecase.rs
+++ b/game_server/rust_app/src/application/schedule/motion_lab_limit_usecase.rs
@@ -12,7 +12,7 @@ use crate::{
         },
         triggergame_simulator::{
             models::{
-                game::{game::Game, game_id::game_id::GameId},
+                game::{game::Game, game_id::game_id::GameId, game_state::GameStateValue},
                 turn::turn_number::turn_number::TurnNumber,
             },
             repositories::{game_repository::GameRepository, turn_repository::TurnRepository},
@@ -60,7 +60,9 @@ impl MotionLabLimitUseCase {
             .await
             .map_err(|e| format!("ゲーム情報の取得に失敗しました: {}", e))?;
 
-        if game.current_turn_number().value() > turn_number {
+        if game.current_turn_number().value() > turn_number
+            || game.game_state().value() == &GameStateValue::Completed
+        {
             // すでに処理済みのターンの場合は何もしない
             return Ok(());
         } else {
@@ -124,6 +126,7 @@ impl MotionLabLimitUseCase {
         player_id: &PlayerId,
     ) -> Result<(), String> {
         let response = WebSocketResponse::NotifyGameState {
+            game_id: game.game_id().value().to_string(),
             message: "対戦相手がリタイアしました。あなたの勝利です。".to_string(),
             state: game.game_state().value().clone(),
             outcome: OutcomeValue::Win,
@@ -149,6 +152,7 @@ impl MotionLabLimitUseCase {
         player_id: &PlayerId,
     ) -> Result<(), String> {
         let response = WebSocketResponse::NotifyGameState {
+            game_id: game.game_id().value().to_string(),
             message: "ゲームは終了しました。通信状況を確認してください。".to_string(),
             state: game.game_state().value().clone(),
             outcome: OutcomeValue::Lose,

--- a/game_server/rust_app/src/application/websocket/websocket_response.rs
+++ b/game_server/rust_app/src/application/websocket/websocket_response.rs
@@ -67,6 +67,8 @@ pub enum WebSocketResponse {
 
     /// ゲーム状態の通知
     NotifyGameState {
+        // ゲームID
+        game_id: String,
         /// ゲーム状態のメッセージ
         message: String,
         /// ゲーム状態の値

--- a/game_server/rust_app/src/domain/triggergame_simulator/models/game/game.rs
+++ b/game_server/rust_app/src/domain/triggergame_simulator/models/game/game.rs
@@ -151,6 +151,11 @@ impl Game {
 
             player1_result_steps.push(player1_step);
             player2_result_steps.push(player2_step);
+
+            if self.is_any_player_units_destroyed(units) {
+                // どちらかのプレイヤーのユニットが全滅している場合は、残りのステップはスキップする
+                break;
+            }
         }
 
         player1_turn.set_steps(player1_result_steps);
@@ -175,6 +180,21 @@ impl Game {
     /// ゲームが終了しているかどうか（最終ターンに達しているか）
     pub fn is_game_finished(&self) -> bool {
         self.current_turn_number.value() >= Self::MAX_TURNS
+    }
+
+    /// どちらかのプレイヤーのユニットが全滅しているか
+    pub fn is_any_player_units_destroyed(&self, units: &Vec<Unit>) -> bool {
+        let player1_units = units
+            .iter()
+            .filter(|u| u.owner_player_id() == self.player1_id())
+            .collect::<Vec<&Unit>>();
+        let player2_units = units
+            .iter()
+            .filter(|u| u.owner_player_id() == self.player2_id())
+            .collect::<Vec<&Unit>>();
+
+        player1_units.iter().all(|u| u.is_bailed_out())
+            || player2_units.iter().all(|u| u.is_bailed_out())
     }
 
     // ゲッター

--- a/game_server/rust_app/src/domain/triggergame_simulator/models/game/visibility.rs
+++ b/game_server/rust_app/src/domain/triggergame_simulator/models/game/visibility.rs
@@ -102,9 +102,10 @@ impl Visibility {
         let viewer_height = self.field_steps[viewer_pos.row() as usize][viewer_pos.col() as usize];
         let target_height = self.field_steps[target_pos.row() as usize][target_pos.col() as usize];
 
-        if path.len() <= 2 {
-            return true;
-        }
+        // 2マス以内なら障害物があっても見えるとするか。。。一旦保留。。。
+        // if path.len() <= 2 {
+        //     return true;
+        // }
 
         for (i, path_pos) in path.iter().enumerate().skip(1).take(path.len() - 2) {
             let obstacle_height =


### PR DESCRIPTION
* ゲーム終了時にダイアログが表示されない
* 前のゲームの終了通知に反応してしまう
* ゲーム終了時のダイアログのターン数が1になってしまう
* ベイルアウト時にトリガー表示が残ってしまう
* 全ターン完了後に動きの設定締切通知が届いてしまう
* ユニットの行動モードの途中でどちらかが全滅してもstepが続いてしまう

## 概要

<!-- このPRで何を変更したかを簡潔に記載 -->

## 関連Issue

- Closes #61 

## 変更内容

- ゲーム終了時にダイアログが表示される
- 別のゲームの終了通知があっても無視する
- ゲーム終了時のダイアログのターン数は現在のターン数に基づく
- ベイルアウト時にトリガー表示は消える
- 全ターン完了後に動きの設定締切通知は出さない
- ユニットの行動モードの途中でどちらかが全滅したらその時点で終了する

## 動作確認

### 確認環境

- [x] local
- [ ] dev

### 手順

1. 
2. 
3. 

### 結果

- [x] 期待通りに動作する
- [x] 既存機能へ副作用がないことを確認した

## 影響範囲

- [x] game-client
- [x] game_server
- [ ] local-websocket-apigateway
- [ ] local-dynamodb-initialize
- [ ] local-eventbridge-scheduler
- [ ] ドキュメントのみ

## テスト

- [ ] 追加/変更した処理に対して必要なテストを実施した
- [ ] 手動確認のみ（理由を下に記載）

手動確認理由（必要時）:

## UI変更（必要時）

- スクリーンショット or 動画を添付

## レビュー観点（任意）

<!-- 特に見てほしい点があれば記載 -->

## チェックリスト

- [x] ブランチ名が規約に沿っている（`feature/*`, `fix/*`, `chore/*`, `docs/*`）
- [x] PRタイトルが規約に沿っている（`<type>: <概要> (#issue番号)`）
- [x] 1PR1目的になっている
- [x] 不要な差分（無関係な整形/リネーム等）がない
- [x] 破壊的変更がある場合、内容と移行手順を記載した

## 備考

上記はあくまで推奨ルールです。従わなくても全然いいですが、迷ったら参考にしてください。
