### PR TITLE
Fix: 対戦終了後のダイアログ表示のバグ修正 (#63)

### DIFF
--- a/game-client/game-logics/GameGrid.tsx
+++ b/game-client/game-logics/GameGrid.tsx
@@ -104,7 +104,7 @@ const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnit
   };
 
   /** ゲーム終了処理 */
-  const handleCompleteGame = (result: GameResult) => {
+  const handleCompleteGame = (friendUnits: FriendUnit[], enemyUnits: EnemyUnit[], result: GameResult) => {
     console.log("ゲーム終了処理を実行します。結果:", result);
     setGameResult(result);
     checkGameState(friendUnits, enemyUnits, currentTurn);

--- a/game-client/game-logics/GameGrid.tsx
+++ b/game-client/game-logics/GameGrid.tsx
@@ -145,7 +145,7 @@ const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnit
         setGameMode("execute");
         setCurrentTurn(data.turn.getTurnNumber());
         motionExecuteDialogRef.current?.show();
-        setMotionExecuteEndTimeState(new Date(Date.now() + 15000));
+        setMotionExecuteEndTimeState(new Date(Date.now() + 15000 + 2000)); // 動きの実行時間（15秒）＋αを設定
         setMotionLabEndTimeState(new Date(data.motionLabEndTime));
       }
     };

--- a/game-client/game-logics/characterManager.ts
+++ b/game-client/game-logics/characterManager.ts
@@ -1,10 +1,12 @@
 'use client';
 
+import { EnemyUnit } from "@/types/EnemyUnit";
 import { CHARACTER_STATUS } from "./config/status";
 import { CharacterImageState } from "./entities/CharacterImageState";
 import { EnemyCharacterState } from "./entities/EnemyCharacterState";
 import { PlayerCharacterState } from "./entities/PlayerCharacterState";
 import { Position } from "./types";
+import { FriendUnit } from "@/types/FriendUnit";
 
 /**
  * キャラクター管理クラス
@@ -232,4 +234,12 @@ export class CharacterManager {
       character.hideSubTriggerFan();
     });
   };
+
+  // ゲッター
+  getUnitsList(): { friendUnits: FriendUnit[]; enemyUnits: EnemyUnit[]; } {
+    return {
+      friendUnits: this.playerCharacters.map(character => (character.getFriendUnit())),
+      enemyUnits: this.enemyCharacters.map(character => (character.getEnemyUnitData())),
+    };
+  }
 }

--- a/game-client/game-logics/entities/EnemyCharacterState.ts
+++ b/game-client/game-logics/entities/EnemyCharacterState.ts
@@ -8,6 +8,7 @@ import { EnemyUnitImage } from "../phaser/game-objects/images/EnemyUnitImage";
 import { GridConfig } from "../types";
 import { CharacterImageState } from "./CharacterImageState";
 import { UnitType } from "@/types/UnitType";
+import { Combat } from "../models/Combat";
 
 /**
  * 敵キャラクターごとの状態管理の型定義
@@ -15,7 +16,7 @@ import { UnitType } from "@/types/UnitType";
 export class EnemyCharacterState extends CharacterImageState {
   constructor(
     scene: Phaser.Scene,
-    enemyUnit: EnemyUnit,
+    private enemyUnit: EnemyUnit,
     hexUtils: HexUtils,
     private gridConfig: GridConfig
   ) {
@@ -65,5 +66,28 @@ export class EnemyCharacterState extends CharacterImageState {
     action.invertPositionForEnemy(this.gridConfig); // エネミー用に座標を反転させる
     action.invertTriggerAngleForEnemy(this.gridConfig); // エネミー用にトリガー角度を反転させる
     this.executeCommonSingleAction(action, onStepComplete);
+  }
+
+  /** 
+   * キャラクターが防御アクションを実行した際の処理
+   * @override CharacterImageStateの同名メソッドをオーバーライドして、エネミーのベイルアウト状態を更新する処理を追加
+   */
+  executeCharacterDefense(
+    combat: Combat
+  ) {
+    super.executeCharacterDefense(combat);
+    if (combat.getIsDefeatedCombat()) {
+      this.setEnemyUnitBailout(true);
+    }
+  }
+
+  // ゲッター
+  getEnemyUnitData() {
+    return this.enemyUnit;
+  }
+
+  // セッター
+  private setEnemyUnitBailout(isBailout: boolean) {
+    this.enemyUnit.isBailout = isBailout;
   }
 }

--- a/game-client/game-logics/entities/EnemyCharacterState.ts
+++ b/game-client/game-logics/entities/EnemyCharacterState.ts
@@ -65,6 +65,7 @@ export class EnemyCharacterState extends CharacterImageState {
   executeCharacterSingleAction(action: Action, onStepComplete: () => void) {
     action.invertPositionForEnemy(this.gridConfig); // エネミー用に座標を反転させる
     action.invertTriggerAngleForEnemy(this.gridConfig); // エネミー用にトリガー角度を反転させる
+    this.setEnemyUnitTypeId(action.getUnitTypeId()); // 敵のユニット種別を更新
     this.executeCommonSingleAction(action, onStepComplete);
   }
 
@@ -76,6 +77,7 @@ export class EnemyCharacterState extends CharacterImageState {
     combat: Combat
   ) {
     super.executeCharacterDefense(combat);
+    this.setEnemyUnitTypeId(this.getUnitTypeId()); // 敵のユニット種別を更新
     if (combat.getIsDefeatedCombat()) {
       this.setEnemyUnitBailout(true);
     }
@@ -89,5 +91,9 @@ export class EnemyCharacterState extends CharacterImageState {
   // セッター
   private setEnemyUnitBailout(isBailout: boolean) {
     this.enemyUnit.isBailout = isBailout;
+  }
+
+  private setEnemyUnitTypeId(unitTypeId: UnitType) {
+    this.enemyUnit.unitTypeId = unitTypeId;
   }
 }

--- a/game-client/game-logics/entities/PlayerCharacterState.ts
+++ b/game-client/game-logics/entities/PlayerCharacterState.ts
@@ -25,7 +25,7 @@ export class PlayerCharacterState extends CharacterImageState {
     /** Phaserシーンクラス */
     scene: Phaser.Scene,
     /** 味方ユニット情報 */
-    friendUnit: FriendUnit,
+    private friendUnit: FriendUnit,
     /** 座標計算系クラス */
     hexUtils: HexUtils,
     /** グリッド設定 */
@@ -184,6 +184,7 @@ export class PlayerCharacterState extends CharacterImageState {
   ) {
     super.executeCharacterDefense(combat);
     if (combat.getIsDefeatedCombat()) {
+      this.setFriendUnitBailout(true);
       this.setActionPointsText(null);
     }
   }
@@ -210,6 +211,10 @@ export class PlayerCharacterState extends CharacterImageState {
     return this.currentStep;
   }
 
+  getFriendUnit() {
+    return this.friendUnit;
+  }
+
   // セッター
   setActionPoints(points: number) {
     this.actionPoints = points;
@@ -217,5 +222,9 @@ export class PlayerCharacterState extends CharacterImageState {
 
   setCompleteText(text: ActionCompletedText | null) {
     this.completeText = text;
+  }
+
+  private setFriendUnitBailout(isBailout: boolean) {
+    this.friendUnit.isBailout = isBailout;
   }
 }

--- a/game-client/game-logics/phaser/scenes/GridCellsScene.ts
+++ b/game-client/game-logics/phaser/scenes/GridCellsScene.ts
@@ -55,7 +55,7 @@ export class GridCellsScene extends Phaser.Scene {
   private isDraggingTrigger: boolean = false; // トリガー扇形をドラッグ中かどうか
   private currentTriggerAngle: number = 0; // 現在のトリガー角度
 
-  constructor(private firstMotionLabEndtime: Date, private friendUnits: FriendUnit[], private enemyUnits: EnemyUnit[], private fieldSteps: number[][], private visibility: boolean[][], private sendServerTurn: (steps: Step[]) => void, private completeGame: (result: GameResult, playerCharacterStates: PlayerCharacterState[], enemyCharacterStates: EnemyCharacterState[]) => void, private handleFinishMotionExecute: () => void) {
+  constructor(private firstMotionLabEndtime: Date, private friendUnits: FriendUnit[], private enemyUnits: EnemyUnit[], private fieldSteps: number[][], private visibility: boolean[][], private sendServerTurn: (steps: Step[]) => void, private completeGame: (friendUnits: FriendUnit[], enemyUnits: EnemyUnit[], result: GameResult) => void, private handleFinishMotionExecute: () => void) {
     super({ key: "GridScene" });
     console.log("GridCellsSceneコンストラクタ: friendUnits =", friendUnits, "enemyUnits =", enemyUnits);
   }
@@ -366,7 +366,8 @@ export class GridCellsScene extends Phaser.Scene {
       },
       /** ゲームの終了処理を実行する */
       completeGame: (result: GameResult) => {
-        this.completeGame(result, this.characterManager.playerCharacters, this.characterManager.enemyCharacters);
+        const { friendUnits, enemyUnits } = this.characterManager.getUnitsList();
+        this.completeGame(friendUnits, enemyUnits, result);
       }
     };
   }

--- a/game-client/game-logics/phaser/scenes/services/__tests__/FieldViewService.test.ts
+++ b/game-client/game-logics/phaser/scenes/services/__tests__/FieldViewService.test.ts
@@ -49,6 +49,15 @@ describe("FieldViewService visibility checks", () => {
     expect(result).toBe(false);
   });
 
+  it("checkUnitsVisibility: (20, 24)から(9, 15)は距離が遠いので不可視", () => {
+    const service = makeService();
+    const result = (service as any).checkUnitsVisibility(
+      { col: 20, row: 24 },
+      { col: 9, row: 15 }
+    );
+    expect(result).toBe(false);
+  });
+
   it("hasLineOfSight: 障害物があるラインは false", () => {
     const service = makeService();
     const result = (service as any).hasLineOfSight(

--- a/game_server/rust_app/src/domain/triggergame_simulator/configs/game_config.rs
+++ b/game_server/rust_app/src/domain/triggergame_simulator/configs/game_config.rs
@@ -37,7 +37,7 @@ impl GameConfig {
             hex_height: (24.0 * (3 as f64).sqrt()) as i32,
             gameboard_width: 36,
             gameboard_height: 36,
-            avoid_weight: 2,
+            avoid_weight: 100,
             damage_weight: 1.0,
             defend_weight: 1.0,
             min_damage: 20,

--- a/game_server/rust_app/src/domain/triggergame_simulator/models/game/game.rs
+++ b/game_server/rust_app/src/domain/triggergame_simulator/models/game/game.rs
@@ -15,7 +15,6 @@ use crate::domain::{
 
 use super::game_id::game_id::GameId;
 use chrono::{DateTime, Utc};
-use itertools::Itertools;
 use uuid::Uuid;
 
 /// Game集約
@@ -113,29 +112,24 @@ impl Game {
         let mut player2_result_steps = Vec::new();
 
         // 各ステップの戦闘演算を開始
-        for (idx, step) in player1_turn
-            .steps()
-            .iter()
-            .zip_longest(player2_turn.steps().iter())
-            .enumerate()
-        {
-            if idx >= GameConfig::get_game_config().motion_execute_seconds() as usize {
-                // ユニットの行動モードでの秒数を超えたらスキップ
-                break;
-            }
+        for idx in 0..GameConfig::get_game_config().motion_execute_seconds() as usize {
+            let player1_step = player1_turn.steps().get(idx);
+            let player2_step = player2_turn.steps().get(idx);
+
             // stepをマージして、両プレイヤーの行動を反映させたステップを作成
             let mut merge_step = Step::new(
                 StepId::new(Uuid::new_v4().to_string()),
                 Vec::new(),
                 Vec::new(),
             );
-            match step {
-                itertools::EitherOrBoth::Both(step1, step2) => {
+            match (player1_step, player2_step) {
+                (Some(step1), Some(step2)) => {
                     merge_step.push_actions(step1.actions());
                     merge_step.push_actions(step2.actions());
                 }
-                itertools::EitherOrBoth::Left(step1) => merge_step.push_actions(step1.actions()),
-                itertools::EitherOrBoth::Right(step2) => merge_step.push_actions(step2.actions()),
+                (Some(step1), None) => merge_step.push_actions(step1.actions()),
+                (None, Some(step2)) => merge_step.push_actions(step2.actions()),
+                (None, None) => {}
             }
             // merge_stepの戦闘演算を開始
             merge_step.step_start(units, &mut self.visibility)?;

--- a/game_server/rust_app/src/domain/triggergame_simulator/models/game/visibility_test.rs
+++ b/game_server/rust_app/src/domain/triggergame_simulator/models/game/visibility_test.rs
@@ -17,6 +17,14 @@ fn check_units_visibility_far_distance_is_false() {
     assert!(!result);
 }
 
+/// checkUnitsVisibility: (20, 24)から(9, 15)は距離が遠いので不可視
+#[test]
+fn check_units_visibility_far_distance_is_false_2() {
+    let visibility = Visibility::create();
+    let result = visibility.check_units_visibility(&Position::new(20, 24), &Position::new(9, 15));
+    assert!(!result);
+}
+
 /// hasLineOfSight: 障害物があるラインは false
 #[test]
 fn has_line_of_sight_with_obstacle_is_false() {

--- a/game_server/rust_app/src/domain/triggergame_simulator/services/step_execution_service.rs
+++ b/game_server/rust_app/src/domain/triggergame_simulator/services/step_execution_service.rs
@@ -1,5 +1,8 @@
 use crate::domain::triggergame_simulator::models::{
-    game::visibility::Visibility, step::step::Step,
+    action::action::Action,
+    action::action_type::action_type::{ActionType, ActionTypeValue},
+    game::visibility::Visibility,
+    step::step::Step,
 };
 use crate::domain::unit_management::models::unit::Unit;
 
@@ -88,7 +91,7 @@ impl StepExecutionService {
     /// - `Err(String)`: 必須のドメイン更新に失敗した場合。
     pub fn apply_action_movements(
         &self,
-        step: &Step,
+        step: &mut Step,
         units: &mut Vec<Unit>,
         visibility: &mut Visibility,
     ) -> Result<(), String> {
@@ -139,6 +142,36 @@ impl StepExecutionService {
                 );
             }
         }
+
+        // actionが未指定のユニットには待機アクションを補完する。
+        let acted_unit_ids = step
+            .actions()
+            .iter()
+            .map(|a| a.unit_id().clone())
+            .collect::<Vec<_>>();
+
+        let wait_actions = units
+            .iter()
+            .filter(|unit| {
+                acted_unit_ids
+                    .iter()
+                    .all(|acted_id| acted_id != unit.unit_id())
+            })
+            .map(|unit| {
+                Action::create(
+                    ActionType::new(ActionTypeValue::Wait),
+                    unit.unit_id().clone(),
+                    unit.unit_type_id().clone(),
+                    unit.position().clone(),
+                    unit.using_main_trigger_id().clone(),
+                    unit.using_sub_trigger_id().clone(),
+                    unit.main_trigger_azimuth().clone(),
+                    unit.sub_trigger_azimuth().clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        step.actions_mut().extend(wait_actions);
 
         Ok(())
     }
@@ -292,12 +325,12 @@ mod tests {
     fn test_apply_action_movements_updates_trigger_at_ap_boundary() {
         // 仕様: APがちょうど1ならトリガー更新は許可される。
         let unit = create_unit_with_ap(1);
-        let step = create_step_for(&unit);
+        let mut step = create_step_for(&unit);
         let mut units = vec![unit.clone()];
         let mut visibility = Visibility::create();
 
         StepExecutionService::new()
-            .apply_action_movements(&step, &mut units, &mut visibility)
+            .apply_action_movements(&mut step, &mut units, &mut visibility)
             .unwrap();
 
         assert_eq!(
@@ -314,11 +347,11 @@ mod tests {
     fn test_apply_action_movements_does_not_update_trigger_when_ap_is_less_than_boundary() {
         // 仕様: APが1未満ならトリガー更新は拒否される。
         let mut units = vec![create_unit_with_ap(0)];
-        let step = create_step_for(&units[0]);
+        let mut step = create_step_for(&units[0]);
         let mut visibility = Visibility::create();
 
         StepExecutionService::new()
-            .apply_action_movements(&step, &mut units, &mut visibility)
+            .apply_action_movements(&mut step, &mut units, &mut visibility)
             .unwrap();
 
         assert_eq!(

--- a/game_server/rust_app/src/domain/unit_management/models/unit/position/position.rs
+++ b/game_server/rust_app/src/domain/unit_management/models/unit/position/position.rs
@@ -45,13 +45,7 @@ impl Position {
         let hex_height = game_config.hex_height();
 
         let x = col * hex_width * 3 / 4 + hex_radius;
-        let y = row * hex_height
-            + if col % 2 == 1 {
-                hex_radius + hex_height / 2
-            } else {
-                0
-            }
-            + hex_radius;
+        let y = row * hex_height + if col % 2 == 1 { hex_height / 2 } else { 0 } + hex_radius;
         (x, y)
     }
 


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記載 -->

## 関連Issue

- Closes #63 

## 変更内容

- 結果表示ダイアログの敵ユニットの画像が表示されない問題の修正
- 結果表示ダイアログに敵味方のベイルアウト状態が反映されるよう修正
- ユニットの行動モードの時間に間の時間(2秒)を追加
- 回避率を下げる調整
- 各キャラクターが15回アクションを設定するようバックエンドを修正

## 動作確認

### 確認環境

- [x] local
- [ ] dev

### 手順

1. 
2. 
3. 

### 結果

- [x] 期待通りに動作する
- [x] 既存機能へ副作用がないことを確認した

## 影響範囲

- [x] game-client
- [x] game_server
- [ ] local-websocket-apigateway
- [ ] local-dynamodb-initialize
- [ ] local-eventbridge-scheduler
- [ ] ドキュメントのみ

## テスト

- [x] 追加/変更した処理に対して必要なテストを実施した
- [ ] 手動確認のみ（理由を下に記載）

手動確認理由（必要時）:

## UI変更（必要時）

- スクリーンショット or 動画を添付

## レビュー観点（任意）

<!-- 特に見てほしい点があれば記載 -->

## チェックリスト

- [x] ブランチ名が規約に沿っている（`feature/*`, `fix/*`, `chore/*`, `docs/*`）
- [ ] PRタイトルが規約に沿っている（`<type>: <概要> (#issue番号)`）
- [ ] 1PR1目的になっている
- [ ] 不要な差分（無関係な整形/リネーム等）がない
- [ ] 破壊的変更がある場合、内容と移行手順を記載した

## 備考

上記はあくまで推奨ルールです。従わなくても全然いいですが、迷ったら参考にしてください。
