### PR TITLE
fix: ベイルアウトした敵ユニットの画像が表示されない問題の修正を対応 (#66)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@
 
 - `feature/123-turn_timeout`
 - `fix/245-invalid_action_order`
-- `refactor/456_code_structure`
+- `refactor/456-code_structure`
 - `docs/contributing_update`
 
 ## 2. コミットメッセージ

--- a/game-client/game-logics/config/status.ts
+++ b/game-client/game-logics/config/status.ts
@@ -3,8 +3,8 @@
  */
 export const CHARACTER_STATUS = {
   MIKUMO_OSAMU: {
-    main: "ASTEROID",
-    sub: "RAYGUST",
+    main: "RAYGUST",
+    sub: "ASTEROID",
     activeCount: 13,
     trion: 2,
     attack: 3,

--- a/game-client/game-logics/config/status.ts
+++ b/game-client/game-logics/config/status.ts
@@ -3,8 +3,6 @@
  */
 export const CHARACTER_STATUS = {
   MIKUMO_OSAMU: {
-    main: "RAYGUST",
-    sub: "ASTEROID",
     activeCount: 13,
     trion: 2,
     attack: 3,
@@ -14,8 +12,6 @@ export const CHARACTER_STATUS = {
     technique: 6,
   },
   KUGA_YUMA: {
-    main: "SCORPION",
-    sub: "SHIELD",
     activeCount: 16,
     trion: 7,
     attack: 9,
@@ -25,8 +21,6 @@ export const CHARACTER_STATUS = {
     technique: 8,
   },
   AMATORI_CHIKA: {
-    main: "IBIS",
-    sub: "BAGWORM",
     activeCount: 12,
     trion: 25,
     attack: 2,
@@ -36,8 +30,6 @@ export const CHARACTER_STATUS = {
     technique: 6,
   },
   HYUSE_KURONIN: {
-    main: "KOGETSU",
-    sub: "SHIELD",
     activeCount: 15,
     trion: 18,
     attack: 8,

--- a/game-client/game-logics/entities/EnemyCharacterState.ts
+++ b/game-client/game-logics/entities/EnemyCharacterState.ts
@@ -77,7 +77,6 @@ export class EnemyCharacterState extends CharacterImageState {
     combat: Combat
   ) {
     super.executeCharacterDefense(combat);
-    this.setEnemyUnitTypeId(this.getUnitTypeId()); // 敵のユニット種別を更新
     if (combat.getIsDefeatedCombat()) {
       this.setEnemyUnitBailout(true);
     }

--- a/game-client/game-logics/phaser/scenes/controllers/TriggerSettingController.ts
+++ b/game-client/game-logics/phaser/scenes/controllers/TriggerSettingController.ts
@@ -68,24 +68,15 @@ export class TriggerSettingController {
       return;
     }
 
-    const characterState = this.deps.characterManager.findCharacterByImage(
-      selectedCharacter.image
-    );
-    // キャラクター状態の取得可否を判定する。
-    if (!characterState) {
-      return;
-    }
-
     const characterKey =
-      characterState.getUnitTypeId() as keyof typeof CHARACTER_STATUS;
+      selectedCharacter.getUnitTypeId() as keyof typeof CHARACTER_STATUS;
     const characterStatus = CHARACTER_STATUS[characterKey];
     // キャラクター定義情報の取得可否を判定する。
     if (!characterStatus) {
       return;
     }
 
-    const triggerName =
-      triggerSettingType === "main" ? characterStatus.main : characterStatus.sub;
+    const triggerName = triggerSettingType === "main" ? selectedCharacter.getFriendUnit().usingMainTriggerId : selectedCharacter.getFriendUnit().usingSubTriggerId;
     const triggerStatus =
       TRIGGER_STATUS[triggerName as keyof typeof TRIGGER_STATUS];
     // トリガー定義情報の取得可否を判定する。
@@ -103,8 +94,8 @@ export class TriggerSettingController {
       "扇形をドラッグして角度を調整し、マウスを離すかクリックで確定してください"
     );
 
-    const initialAngle = characterState.direction
-      ? characterState.direction[triggerSettingType]
+    const initialAngle = selectedCharacter.direction
+      ? selectedCharacter.direction[triggerSettingType]
       : 0;
     this.deps.setCurrentTriggerAngle(initialAngle);
 
@@ -150,16 +141,8 @@ export class TriggerSettingController {
       return;
     }
 
-    const characterState = this.deps.characterManager.findCharacterByImage(
-      selectedCharacter.image
-    );
-    // キャラクター状態の取得可否を判定する。
-    if (!characterState) {
-      return;
-    }
-
     const characterKey =
-      characterState.getUnitTypeId() as keyof typeof CHARACTER_STATUS;
+      selectedCharacter.getUnitTypeId() as keyof typeof CHARACTER_STATUS;
     const characterStatus = CHARACTER_STATUS[characterKey];
     // キャラクター定義情報の取得可否を判定する。
     if (!characterStatus) {
@@ -167,7 +150,7 @@ export class TriggerSettingController {
     }
 
     const triggerName =
-      triggerSettingType === "main" ? characterStatus.main : characterStatus.sub;
+      triggerSettingType === "main" ? selectedCharacter.getFriendUnit().usingMainTriggerId : selectedCharacter.getFriendUnit().usingSubTriggerId;
     const triggerStatus =
       TRIGGER_STATUS[triggerName as keyof typeof TRIGGER_STATUS];
     // トリガー定義情報の取得可否を判定する。
@@ -255,19 +238,11 @@ export class TriggerSettingController {
       return;
     }
 
-    const characterState = this.deps.characterManager.findCharacterByImage(
-      selectedCharacter.image
-    );
-    // キャラクター状態の取得可否を判定する。
-    if (!characterState) {
-      return;
-    }
-
-    let directions = characterState.direction;
+    let directions = selectedCharacter.direction;
     // 方向情報が未初期化なら初期化する。
     if (!directions) {
       directions = { main: 0, sub: 0 };
-      characterState.direction = directions;
+      selectedCharacter.direction = directions;
     }
 
     directions[triggerSettingType] = direction;

--- a/game-client/game-logics/phaser/scenes/services/TurnPlanner.ts
+++ b/game-client/game-logics/phaser/scenes/services/TurnPlanner.ts
@@ -183,23 +183,15 @@ export class TurnPlanner {
       return;
     }
 
-    const characterState = this.deps.characterManager.findPlayerCharacterByImage(
-      this.deps.characterManager.selectedCharacter.image
-    );
-    // 選択キャラクターの状態を取得できたかを判定する。
+    const characterState = this.deps.characterManager.selectedCharacter;
     if (!characterState) {
+      console.error("選択キャラクターの状態が見つかりませんでした");
       return;
     }
 
     const directions = characterState.direction;
-    const mainTrigger =
-      CHARACTER_STATUS[
-        characterState.getUnitTypeId() as keyof typeof CHARACTER_STATUS
-      ]?.main ?? null;
-    const subTrigger =
-      CHARACTER_STATUS[
-        characterState.getUnitTypeId() as keyof typeof CHARACTER_STATUS
-      ]?.sub ?? null;
+    const mainTrigger = characterState.getFriendUnit().usingMainTriggerId;
+    const subTrigger = characterState.getFriendUnit().usingSubTriggerId;
 
     // 方向情報とトリガー情報が履歴記録に必要な形で揃っているかを判定する。
     if (!directions || !mainTrigger || !subTrigger) {

--- a/game_server/rust_app/src/domain/triggergame_simulator/models/combat/combat.rs
+++ b/game_server/rust_app/src/domain/triggergame_simulator/models/combat/combat.rs
@@ -177,7 +177,11 @@ impl Combat {
 
         if !is_avoided.value() {
             // ダメージ量の計算
-            if is_defender_facing_attacker_main && is_defender_facing_attacker_sub {
+            if is_defender_facing_attacker_main
+                && defender_main_trigger_status.defense() > 0
+                && is_defender_facing_attacker_sub
+                && defender_sub_trigger_status.defense() > 0
+            {
                 // 両防御の場合
                 let (main_trigger_damage, sub_trigger_damage) = Self::calculate_full_guard_damage(
                     attacker_base_attack,
@@ -197,7 +201,10 @@ impl Combat {
                 if main_trigger_hp <= 0 || sub_trigger_hp <= 0 {
                     is_defeated = true;
                 }
-            } else if is_defender_facing_attacker_main && !is_defender_facing_attacker_sub {
+            } else if is_defender_facing_attacker_main
+                && defender_main_trigger_status.defense() > 0
+                && !is_defender_facing_attacker_sub
+            {
                 // 片方防御の場合（メイントリガーのみ防御）
                 let damage = Self::calculate_partial_guard_damage(
                     attacker_base_attack,
@@ -208,7 +215,10 @@ impl Combat {
                     defender_main_trigger_status.defense(),
                 );
                 main_trigger_hp -= damage;
-            } else if !is_defender_facing_attacker_main && is_defender_facing_attacker_sub {
+            } else if !is_defender_facing_attacker_main
+                && is_defender_facing_attacker_sub
+                && defender_sub_trigger_status.defense() > 0
+            {
                 // 片方防御の場合（サブトリガーのみ防御）
                 let damage = Self::calculate_partial_guard_damage(
                     attacker_base_attack,
@@ -219,6 +229,9 @@ impl Combat {
                     defender_sub_trigger_status.defense(),
                 );
                 sub_trigger_hp -= damage;
+            } else {
+                // 両トリガーが防御トリガーでないときは即撃墜
+                is_defeated = true;
             }
         }
 


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記載 -->
* ベイルアウトした敵ユニットの画像が表示されない問題の修正を対応。
* あまり良くないがその他不具合も修正

## 関連Issue

- Closes #66 

## 変更内容

- フロント側のCHARACTER_STATUSにトリガー情報が紐付いているので除去
- 選択したキャラクターのイメージから選択したキャラクターのステートを取得してくる二重処理の解消
- 更新されてないUnitTypeIdからステートを更新してしまうコードを除外
- 防御能力のないトリガーで防御できてしまう問題の修正

## 動作確認

### 確認環境

- [x] local
- [ ] dev

### 手順

1. 
2. 
3. 

### 結果

- [ ] 期待通りに動作する
- [ ] 既存機能へ副作用がないことを確認した

## 影響範囲

- [x] game-client
- [x] game_server
- [ ] local-websocket-apigateway
- [ ] local-dynamodb-initialize
- [ ] local-eventbridge-scheduler
- [ ] ドキュメントのみ

## テスト

- [ ] 追加/変更した処理に対して必要なテストを実施した
- [ ] 手動確認のみ（理由を下に記載）

手動確認理由（必要時）:

## UI変更（必要時）

- スクリーンショット or 動画を添付

## レビュー観点（任意）

<!-- 特に見てほしい点があれば記載 -->

## チェックリスト

- [x] ブランチ名が規約に沿っている（`feature/*`, `fix/*`, `chore/*`, `docs/*`）
- [x] PRタイトルが規約に沿っている（`<type>: <概要> (#issue番号)`）
- [ ] 1PR1目的になっている
- [x] 不要な差分（無関係な整形/リネーム等）がない
- [ ] 破壊的変更がある場合、内容と移行手順を記載した

## 備考

上記はあくまで推奨ルールです。従わなくても全然いいですが、迷ったら参考にしてください。
