### PR TITLE
feat: WS切断時にマッチングを中断する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.copilot-tracking/

--- a/game_server/rust_app/src/application/game/get_game_state_usecase.rs
+++ b/game_server/rust_app/src/application/game/get_game_state_usecase.rs
@@ -185,6 +185,17 @@ mod tests {
         async fn get_connection_id(&self, _player_id: &str) -> Result<String, String> {
             Ok(self.connection_id.clone())
         }
+
+        async fn get_player_id_by_connection_id(
+            &self,
+            _connection_id: &str,
+        ) -> Result<Option<String>, String> {
+            Ok(None)
+        }
+
+        async fn delete_by_connection_id(&self, _connection_id: &str) -> Result<(), String> {
+            Ok(())
+        }
     }
 
     struct MockWebSocketSender {

--- a/game_server/rust_app/src/application/matchmaking.rs
+++ b/game_server/rust_app/src/application/matchmaking.rs
@@ -1,2 +1,3 @@
+pub mod disconnect_usecase;
 pub mod matchmaking_application_service;
 pub mod matchmaking_dto;

--- a/game_server/rust_app/src/application/matchmaking/disconnect_usecase.rs
+++ b/game_server/rust_app/src/application/matchmaking/disconnect_usecase.rs
@@ -127,6 +127,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// 未知の connection_id では副作用を起こさず成功終了することを検証する
     async fn execute_unknown_connection_is_noop() {
         let connection_repository = Arc::new(MockConnectionRepository::default());
         let matching_repository = Arc::new(MockMatchingRepository::default());
@@ -143,6 +144,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// 接続中プレイヤー切断時に待機中断と接続削除を順に実行することを検証する
     async fn execute_waiting_player_interrupts_then_deletes_connection() {
         let connection_repository = Arc::new(MockConnectionRepository {
             lookup_result: Mutex::new(Some("player-1".to_string())),
@@ -175,6 +177,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// 同一 connection_id に対する再実行で結果が収束することを検証する
     async fn execute_is_idempotent_for_same_connection_id() {
         let connection_repository = Arc::new(MockConnectionRepository {
             lookup_result: Mutex::new(Some("player-1".to_string())),

--- a/game_server/rust_app/src/application/matchmaking/disconnect_usecase.rs
+++ b/game_server/rust_app/src/application/matchmaking/disconnect_usecase.rs
@@ -1,0 +1,210 @@
+use std::sync::Arc;
+
+use crate::domain::{
+    matching_management::repositories::matching_repository::MatchingRepository,
+    player_management::repositories::connection_repository::ConnectionRepository,
+};
+
+pub struct DisconnectUseCase {
+    connection_repository: Arc<dyn ConnectionRepository>,
+    matching_repository: Arc<dyn MatchingRepository>,
+}
+
+impl DisconnectUseCase {
+    pub fn new(
+        connection_repository: Arc<dyn ConnectionRepository>,
+        matching_repository: Arc<dyn MatchingRepository>,
+    ) -> Self {
+        Self {
+            connection_repository,
+            matching_repository,
+        }
+    }
+
+    /// 切断時の後始末を行う。
+    ///
+    /// ポリシー:
+    /// - 不明な connection_id は成功扱い (no-op)
+    /// - マッチング中断は waiting(InProgress) のみ対象
+    /// - Completed を Interrupted で上書きしない (repository 側の条件更新)
+    /// - 同一 disconnect の再実行は収束する (idempotent)
+    pub async fn execute(&self, connection_id: &str) -> Result<(), String> {
+        let maybe_player_id = self
+            .connection_repository
+            .get_player_id_by_connection_id(connection_id)
+            .await?;
+
+        let Some(player_id) = maybe_player_id else {
+            return Ok(());
+        };
+
+        self.matching_repository
+            .interrupt_waiting_by_player_id(&player_id)
+            .await?;
+
+        self.connection_repository
+            .delete_by_connection_id(connection_id)
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Default)]
+    struct MockConnectionRepository {
+        lookup_result: Mutex<Option<String>>,
+        deleted_connection_ids: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl ConnectionRepository for MockConnectionRepository {
+        async fn save(&self, _player_id: &str, _connection_id: &str) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn get_connection_id(&self, _player_id: &str) -> Result<String, String> {
+            Err("not used in this test".to_string())
+        }
+
+        async fn get_player_id_by_connection_id(
+            &self,
+            _connection_id: &str,
+        ) -> Result<Option<String>, String> {
+            Ok(self.lookup_result.lock().unwrap().clone())
+        }
+
+        async fn delete_by_connection_id(&self, connection_id: &str) -> Result<(), String> {
+            self.deleted_connection_ids
+                .lock()
+                .unwrap()
+                .push(connection_id.to_string());
+            self.lookup_result.lock().unwrap().take();
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct MockMatchingRepository {
+        interrupted_player_ids: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl MatchingRepository for MockMatchingRepository {
+        async fn save(
+            &self,
+            _matching: &crate::domain::matching_management::models::matching::Matching,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn update(
+            &self,
+            _matching: &crate::domain::matching_management::models::matching::Matching,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn get_latest_waiting_matching(
+            &self,
+        ) -> Result<Option<crate::domain::matching_management::models::matching::Matching>, String>
+        {
+            Ok(None)
+        }
+
+        async fn interrupt_waiting_by_player_id(&self, player_id: &str) -> Result<(), String> {
+            self.interrupted_player_ids
+                .lock()
+                .unwrap()
+                .push(player_id.to_string());
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_unknown_connection_is_noop() {
+        let connection_repository = Arc::new(MockConnectionRepository::default());
+        let matching_repository = Arc::new(MockMatchingRepository::default());
+
+        let usecase = DisconnectUseCase::new(connection_repository.clone(), matching_repository);
+
+        let result = usecase.execute("conn-unknown").await;
+        assert!(result.is_ok());
+        assert!(connection_repository
+            .deleted_connection_ids
+            .lock()
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn execute_waiting_player_interrupts_then_deletes_connection() {
+        let connection_repository = Arc::new(MockConnectionRepository {
+            lookup_result: Mutex::new(Some("player-1".to_string())),
+            deleted_connection_ids: Mutex::new(vec![]),
+        });
+        let matching_repository = Arc::new(MockMatchingRepository::default());
+
+        let usecase =
+            DisconnectUseCase::new(connection_repository.clone(), matching_repository.clone());
+
+        let result = usecase.execute("conn-1").await;
+        assert!(result.is_ok());
+
+        assert_eq!(
+            matching_repository
+                .interrupted_player_ids
+                .lock()
+                .unwrap()
+                .as_slice(),
+            ["player-1"]
+        );
+        assert_eq!(
+            connection_repository
+                .deleted_connection_ids
+                .lock()
+                .unwrap()
+                .as_slice(),
+            ["conn-1"]
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_is_idempotent_for_same_connection_id() {
+        let connection_repository = Arc::new(MockConnectionRepository {
+            lookup_result: Mutex::new(Some("player-1".to_string())),
+            deleted_connection_ids: Mutex::new(vec![]),
+        });
+        let matching_repository = Arc::new(MockMatchingRepository::default());
+
+        let usecase =
+            DisconnectUseCase::new(connection_repository.clone(), matching_repository.clone());
+
+        let first = usecase.execute("conn-1").await;
+        let second = usecase.execute("conn-1").await;
+
+        assert!(first.is_ok());
+        assert!(second.is_ok());
+        assert_eq!(
+            matching_repository
+                .interrupted_player_ids
+                .lock()
+                .unwrap()
+                .as_slice(),
+            ["player-1"]
+        );
+        assert_eq!(
+            connection_repository
+                .deleted_connection_ids
+                .lock()
+                .unwrap()
+                .as_slice(),
+            ["conn-1"]
+        );
+    }
+}

--- a/game_server/rust_app/src/domain/matching_management/repositories/matching_repository.rs
+++ b/game_server/rust_app/src/domain/matching_management/repositories/matching_repository.rs
@@ -12,4 +12,11 @@ pub trait MatchingRepository: Send + Sync {
 
     /// 最新の待機中マッチングを取得
     async fn get_latest_waiting_matching(&self) -> Result<Option<Matching>, String>;
+
+    /// 指定プレイヤーの waiting(InProgress) マッチングを中断する。
+    ///
+    /// 実装は以下を満たすこと:
+    /// - Completed を Interrupted で上書きしない
+    /// - 条件に一致しない場合は no-op で成功 (idempotent)
+    async fn interrupt_waiting_by_player_id(&self, player_id: &str) -> Result<(), String>;
 }

--- a/game_server/rust_app/src/domain/player_management/repositories/connection_repository.rs
+++ b/game_server/rust_app/src/domain/player_management/repositories/connection_repository.rs
@@ -8,4 +8,13 @@ pub trait ConnectionRepository: Send + Sync {
 
     /// コネクション情報を取得
     async fn get_connection_id(&self, player_id: &str) -> Result<String, String>;
+
+    /// connection_id から player_id を逆引きする
+    async fn get_player_id_by_connection_id(
+        &self,
+        connection_id: &str,
+    ) -> Result<Option<String>, String>;
+
+    /// connection_id に紐づくコネクション情報を削除する
+    async fn delete_by_connection_id(&self, connection_id: &str) -> Result<(), String>;
 }

--- a/game_server/rust_app/src/infrastructure/dynamodb/connection_dynamodb_repository.rs
+++ b/game_server/rust_app/src/infrastructure/dynamodb/connection_dynamodb_repository.rs
@@ -9,6 +9,8 @@ use aws_sdk_dynamodb::types::AttributeValue;
 use aws_sdk_dynamodb::Client as DynamoDbClient;
 use std::collections::HashMap;
 
+const CONNECTION_ID_INDEX_NAME: &str = "ConnectionIdIndex";
+
 /// DynamoDBを使用したConnectionリポジトリの実装
 /// このリポジトリはドメインの外部に位置します
 /// Lambdaでの特有のコネクション管理処理を担当します
@@ -84,5 +86,53 @@ impl ConnectionRepository for DynamoDbConnectionRepository {
             .ok_or("connection_id not found")?;
 
         Ok(connection_id_str.to_string())
+    }
+
+    async fn get_player_id_by_connection_id(
+        &self,
+        connection_id: &str,
+    ) -> Result<Option<String>, String> {
+        let result = self
+            .client
+            .query()
+            .table_name(self.connections_table.as_str())
+            .index_name(CONNECTION_ID_INDEX_NAME)
+            .key_condition_expression("connection_id = :connection_id")
+            .expression_attribute_values(
+                ":connection_id",
+                AttributeValue::S(connection_id.to_string()),
+            )
+            .limit(1)
+            .send()
+            .await
+            .map_err(|e| format!("Failed to reverse lookup player_id: {}", e))?;
+
+        let Some(item) = result.items().first() else {
+            return Ok(None);
+        };
+
+        let player_id = item
+            .get("player_id")
+            .and_then(|v| v.as_s().ok())
+            .ok_or("player_id not found")?
+            .to_string();
+
+        Ok(Some(player_id))
+    }
+
+    async fn delete_by_connection_id(&self, connection_id: &str) -> Result<(), String> {
+        let Some(player_id) = self.get_player_id_by_connection_id(connection_id).await? else {
+            return Ok(());
+        };
+
+        self.client
+            .delete_item()
+            .table_name(self.connections_table.as_str())
+            .key("player_id", AttributeValue::S(player_id))
+            .send()
+            .await
+            .map_err(|e| format!("Failed to delete connection: {}", e))?;
+
+        Ok(())
     }
 }

--- a/game_server/rust_app/src/infrastructure/dynamodb/connection_dynamodb_repository_test.rs
+++ b/game_server/rust_app/src/infrastructure/dynamodb/connection_dynamodb_repository_test.rs
@@ -45,6 +45,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// Connections テーブルへ player_id と connection_id の紐付けを保存できることを検証する
     async fn test_save_connection() {
         let player_id = "550e8400-e29b-41d4-a716-446655440001";
         let connection_id = "test-connection-456";
@@ -67,6 +68,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// player_id から connection_id を取得できることを検証する
     async fn test_get_connection_id_success() {
         let player_id = "550e8400-e29b-41d4-a716-446655440001";
         let connection_id = "test-connection-456";
@@ -104,6 +106,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// 未登録の player_id では期待どおりエラーを返すことを検証する
     async fn test_get_connection_id_not_found() {
         let player_id = "550e8400-e29b-41d4-a716-446655440001";
         let connection_id = "test-connection-456";
@@ -129,6 +132,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// GSI を使った reverse lookup で connection_id から player_id を取得できることを検証する
     async fn test_get_player_id_by_connection_id_success() {
         let player_id = "550e8400-e29b-41d4-a716-446655440001";
         let connection_id = "test-connection-456";
@@ -163,6 +167,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// reverse lookup 対象が存在しない場合に None を返すことを検証する
     async fn test_get_player_id_by_connection_id_not_found() {
         let connection_id = "test-connection-456";
 
@@ -182,6 +187,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// reverse lookup 後に対象 connection を削除できることを検証する
     async fn test_delete_by_connection_id_success() {
         let player_id = "550e8400-e29b-41d4-a716-446655440001";
         let connection_id = "test-connection-456";
@@ -217,6 +223,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// 削除対象が存在しない場合でも no-op で成功することを検証する
     async fn test_delete_by_connection_id_noop_when_not_found() {
         let connection_id = "test-connection-456";
 

--- a/game_server/rust_app/src/infrastructure/dynamodb/connection_dynamodb_repository_test.rs
+++ b/game_server/rust_app/src/infrastructure/dynamodb/connection_dynamodb_repository_test.rs
@@ -4,8 +4,10 @@ mod tests {
     use crate::domain::player_management::repositories::connection_repository::ConnectionRepository;
     use aws_sdk_dynamodb::{
         config::{BehaviorVersion, Region},
+        operation::delete_item::{DeleteItemInput, DeleteItemOutput},
         operation::get_item::{GetItemInput, GetItemOutput},
         operation::put_item::{PutItemInput, PutItemOutput},
+        operation::query::{QueryInput, QueryOutput},
         types::AttributeValue,
         Client, Config,
     };
@@ -17,6 +19,21 @@ mod tests {
         let mock_interceptor = MockResponseInterceptor::new()
             .rule_mode(RuleMode::MatchAny)
             .with_rule(&rule);
+
+        let config = Config::builder()
+            .behavior_version(BehaviorVersion::latest())
+            .region(Region::new("ap-northeast-1"))
+            .interceptor(mock_interceptor)
+            .build();
+
+        Client::from_conf(config)
+    }
+
+    fn setup_mock_client_with_rules(rules: &[Rule]) -> Client {
+        let mut mock_interceptor = MockResponseInterceptor::new().rule_mode(RuleMode::MatchAny);
+        for rule in rules {
+            mock_interceptor = mock_interceptor.with_rule(rule);
+        }
 
         let config = Config::builder()
             .behavior_version(BehaviorVersion::latest())
@@ -109,5 +126,109 @@ mod tests {
             result.unwrap_err(),
             format!("Connectionが見つかりません: {}", player_id)
         );
+    }
+
+    #[tokio::test]
+    async fn test_get_player_id_by_connection_id_success() {
+        let player_id = "550e8400-e29b-41d4-a716-446655440001";
+        let connection_id = "test-connection-456";
+
+        let mut item = HashMap::new();
+        item.insert(
+            "connection_id".to_string(),
+            AttributeValue::S(connection_id.to_string()),
+        );
+        item.insert(
+            "player_id".to_string(),
+            AttributeValue::S(player_id.to_string()),
+        );
+
+        let query_rule = mock!(Client::query)
+            .match_requests(|_: &QueryInput| true)
+            .then_output(move || {
+                QueryOutput::builder()
+                    .set_items(Some(vec![item.clone()]))
+                    .build()
+            });
+
+        let client = setup_mock_client(query_rule);
+        let repo = DynamoDbConnectionRepository::new(client);
+
+        let result = repo
+            .get_player_id_by_connection_id(connection_id)
+            .await
+            .expect("reverse lookup should succeed");
+
+        assert_eq!(result.as_deref(), Some(player_id));
+    }
+
+    #[tokio::test]
+    async fn test_get_player_id_by_connection_id_not_found() {
+        let connection_id = "test-connection-456";
+
+        let query_rule = mock!(Client::query)
+            .match_requests(|_: &QueryInput| true)
+            .then_output(|| QueryOutput::builder().build());
+
+        let client = setup_mock_client(query_rule);
+        let repo = DynamoDbConnectionRepository::new(client);
+
+        let result = repo
+            .get_player_id_by_connection_id(connection_id)
+            .await
+            .expect("reverse lookup should succeed");
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delete_by_connection_id_success() {
+        let player_id = "550e8400-e29b-41d4-a716-446655440001";
+        let connection_id = "test-connection-456";
+
+        let mut item = HashMap::new();
+        item.insert(
+            "connection_id".to_string(),
+            AttributeValue::S(connection_id.to_string()),
+        );
+        item.insert(
+            "player_id".to_string(),
+            AttributeValue::S(player_id.to_string()),
+        );
+
+        let query_rule = mock!(Client::query)
+            .match_requests(|_: &QueryInput| true)
+            .then_output(move || {
+                QueryOutput::builder()
+                    .set_items(Some(vec![item.clone()]))
+                    .build()
+            });
+
+        let delete_rule = mock!(Client::delete_item)
+            .match_requests(|_: &DeleteItemInput| true)
+            .then_output(|| DeleteItemOutput::builder().build());
+
+        let client = setup_mock_client_with_rules(&[query_rule, delete_rule]);
+        let repo = DynamoDbConnectionRepository::new(client);
+
+        let result = repo.delete_by_connection_id(connection_id).await;
+
+        assert!(result.is_ok(), "delete should succeed: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn test_delete_by_connection_id_noop_when_not_found() {
+        let connection_id = "test-connection-456";
+
+        let query_rule = mock!(Client::query)
+            .match_requests(|_: &QueryInput| true)
+            .then_output(|| QueryOutput::builder().build());
+
+        let client = setup_mock_client(query_rule);
+        let repo = DynamoDbConnectionRepository::new(client);
+
+        let result = repo.delete_by_connection_id(connection_id).await;
+
+        assert!(result.is_ok(), "delete no-op should succeed: {:?}", result.err());
     }
 }

--- a/game_server/rust_app/src/infrastructure/dynamodb/matching_dynamodb_repository.rs
+++ b/game_server/rust_app/src/infrastructure/dynamodb/matching_dynamodb_repository.rs
@@ -10,6 +10,7 @@ use crate::domain::player_management::models::player::player_id::player_id::Play
 use async_trait::async_trait;
 use aws_sdk_dynamodb::types::AttributeValue;
 use aws_sdk_dynamodb::Client as DynamoDbClient;
+use chrono::Utc;
 use std::collections::HashMap;
 
 pub struct DynamoDbMatchingRepository {
@@ -209,5 +210,62 @@ impl MatchingRepository for DynamoDbMatchingRepository {
             MatchingEndDatetime::new(None),
             MatchingStatus::new_string(matching_status_str),
         )))
+    }
+
+    async fn interrupt_waiting_by_player_id(&self, player_id: &str) -> Result<(), String> {
+        // InProgress のみを GSI で絞り、対象プレイヤーのみ更新する。
+        let query_result = self
+            .client
+            .query()
+            .table_name(self.matchings_table.as_str())
+            .index_name("MatchingStatusIndex")
+            .key_condition_expression("matching_status = :status")
+            .filter_expression("player1_id = :player_id")
+            .expression_attribute_values(":player_id", AttributeValue::S(player_id.to_string()))
+            .expression_attribute_values(
+                ":status",
+                AttributeValue::S(MatchingStatusValue::InProgress.to_string()),
+            )
+            .send()
+            .await
+            .map_err(|e| format!("Failed to query waiting matching by player_id: {}", e))?;
+
+        for item in query_result.items() {
+            let Some(matching_id) = item.get("matching_id").and_then(|v| v.as_s().ok()) else {
+                continue;
+            };
+
+            let update_result = self
+                .client
+                .update_item()
+                .table_name(self.matchings_table.as_str())
+                .key("matching_id", AttributeValue::S(matching_id.to_string()))
+                .update_expression("SET matching_status = :interrupted, matching_end_datetime = :end_datetime")
+                .condition_expression("matching_status = :in_progress")
+                .expression_attribute_values(
+                    ":interrupted",
+                    AttributeValue::S(MatchingStatusValue::Interrupted.to_string()),
+                )
+                .expression_attribute_values(
+                    ":in_progress",
+                    AttributeValue::S(MatchingStatusValue::InProgress.to_string()),
+                )
+                .expression_attribute_values(
+                    ":end_datetime",
+                    AttributeValue::S(Utc::now().to_rfc3339()),
+                )
+                .send()
+                .await;
+
+            if let Err(e) = update_result {
+                // 競合で Completed 済みの場合は条件不一致のため no-op 扱い。
+                if e.to_string().contains("ConditionalCheckFailedException") {
+                    continue;
+                }
+                return Err(format!("Failed to interrupt waiting matching: {}", e));
+            }
+        }
+
+        Ok(())
     }
 }

--- a/game_server/rust_app/src/infrastructure/dynamodb/matching_dynamodb_repository_test.rs
+++ b/game_server/rust_app/src/infrastructure/dynamodb/matching_dynamodb_repository_test.rs
@@ -42,6 +42,21 @@ mod tests {
         Client::from_conf(config)
     }
 
+    fn setup_mock_client_with_rules(rules: &[Rule]) -> Client {
+        let mut mock_interceptor = MockResponseInterceptor::new().rule_mode(RuleMode::MatchAny);
+        for rule in rules {
+            mock_interceptor = mock_interceptor.with_rule(rule);
+        }
+
+        let config = Config::builder()
+            .behavior_version(BehaviorVersion::latest())
+            .region(Region::new("ap-northeast-1"))
+            .interceptor(mock_interceptor)
+            .build();
+
+        Client::from_conf(config)
+    }
+
     #[tokio::test]
     async fn test_save_matching() {
         let datetime = Utc::now();
@@ -150,4 +165,59 @@ mod tests {
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());
     }
+
+    #[tokio::test]
+    async fn test_interrupt_waiting_by_player_id_success() {
+        let player_id = "550e8400-e29b-41d4-a716-446655440001";
+        let matching_id = Uuid::new_v4().to_string();
+        let mut item = HashMap::new();
+        item.insert(
+            "matching_id".to_string(),
+            AttributeValue::S(matching_id.to_string()),
+        );
+        item.insert(
+            "player1_id".to_string(),
+            AttributeValue::S(player_id.to_string()),
+        );
+        item.insert(
+            "matching_status".to_string(),
+            AttributeValue::S(MatchingStatusValue::InProgress.to_string()),
+        );
+
+        let query_rule = mock!(Client::query)
+            .match_requests(|_: &QueryInput| true)
+            .then_output(move || {
+                QueryOutput::builder()
+                    .set_items(Some(vec![item.clone()]))
+                    .build()
+            });
+
+        let update_rule = mock!(Client::update_item)
+            .match_requests(|req: &UpdateItemInput| {
+                req.condition_expression() == Some("matching_status = :in_progress")
+            })
+            .then_output(|| UpdateItemOutput::builder().build());
+
+        let client = setup_mock_client_with_rules(&[query_rule, update_rule]);
+        let repo = DynamoDbMatchingRepository::new(client);
+
+        let result = repo.interrupt_waiting_by_player_id(player_id).await;
+        assert!(result.is_ok(), "interrupt should succeed: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn test_interrupt_waiting_by_player_id_noop_when_not_found() {
+        let player_id = "550e8400-e29b-41d4-a716-446655440001";
+
+        let query_rule = mock!(Client::query)
+            .match_requests(|_: &QueryInput| true)
+            .then_output(|| QueryOutput::builder().build());
+
+        let client = setup_mock_client(query_rule);
+        let repo = DynamoDbMatchingRepository::new(client);
+
+        let result = repo.interrupt_waiting_by_player_id(player_id).await;
+        assert!(result.is_ok(), "interrupt no-op should succeed: {:?}", result.err());
+    }
+
 }

--- a/game_server/rust_app/src/infrastructure/dynamodb/matching_dynamodb_repository_test.rs
+++ b/game_server/rust_app/src/infrastructure/dynamodb/matching_dynamodb_repository_test.rs
@@ -58,6 +58,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// マッチング情報を新規保存できることを検証する
     async fn test_save_matching() {
         let datetime = Utc::now();
         let uuid1 = "550e8400-e29b-41d4-a716-446655440001";
@@ -84,6 +85,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// マッチング情報を更新できることを検証する
     async fn test_update_matching() {
         let datetime = Utc::now();
         let uuid1 = "550e8400-e29b-41d4-a716-446655440001";
@@ -110,6 +112,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// 待機中マッチングが存在する場合に最新1件を取得できることを検証する
     async fn test_get_latest_waiting_matching_found() {
         let matching_id = MatchingId::new(Uuid::new_v4().to_string());
         let uuid1 = "550e8400-e29b-41d4-a716-446655440001";
@@ -152,6 +155,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// 待機中マッチングが存在しない場合に None を返すことを検証する
     async fn test_get_latest_waiting_matching_not_found() {
         // GetItemでアイテムが見つからないレスポンスをモック
         let query_rule = mock!(Client::query)
@@ -167,6 +171,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// 指定プレイヤーの待機中マッチングを Interrupted へ更新できることを検証する
     async fn test_interrupt_waiting_by_player_id_success() {
         let player_id = "550e8400-e29b-41d4-a716-446655440001";
         let matching_id = Uuid::new_v4().to_string();
@@ -202,10 +207,15 @@ mod tests {
         let repo = DynamoDbMatchingRepository::new(client);
 
         let result = repo.interrupt_waiting_by_player_id(player_id).await;
-        assert!(result.is_ok(), "interrupt should succeed: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "interrupt should succeed: {:?}",
+            result.err()
+        );
     }
 
     #[tokio::test]
+    /// 対象待機が存在しない場合に no-op で成功することを検証する
     async fn test_interrupt_waiting_by_player_id_noop_when_not_found() {
         let player_id = "550e8400-e29b-41d4-a716-446655440001";
 
@@ -217,7 +227,10 @@ mod tests {
         let repo = DynamoDbMatchingRepository::new(client);
 
         let result = repo.interrupt_waiting_by_player_id(player_id).await;
-        assert!(result.is_ok(), "interrupt no-op should succeed: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "interrupt no-op should succeed: {:?}",
+            result.err()
+        );
     }
-
 }

--- a/game_server/rust_app/src/lib.rs
+++ b/game_server/rust_app/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod application;
+pub mod config;
+pub mod domain;
+pub mod infrastructure;

--- a/game_server/rust_app/src/main.rs
+++ b/game_server/rust_app/src/main.rs
@@ -14,7 +14,10 @@ use crate::{
         game::{
             get_game_state_usecase::GetGameStateUseCase, process_turn_usecase::ProcessTurnUseCase,
         },
-        matchmaking::matchmaking_application_service::MatchmakingApplicationService,
+        matchmaking::{
+            disconnect_usecase::DisconnectUseCase,
+            matchmaking_application_service::MatchmakingApplicationService,
+        },
         schedule::{
             motion_lab_limit_usecase::MotionLabLimitUseCase, schedule_maker::ScheduleMaker,
         },
@@ -132,10 +135,21 @@ async fn handle_websocket_event(event: WebSocketEvent) -> Result<Response, Error
             println!("Client connected: {}", event.request_context.connection_id);
         }
         "$disconnect" => {
-            println!(
-                "Client disconnected: {}",
-                event.request_context.connection_id
+            let connection_id = event.request_context.connection_id.clone();
+            println!("Client disconnected: {}", connection_id);
+
+            let dynamo_client = create_dynamodb_client().await;
+            let connection_repository = DynamoDbConnectionRepository::new(dynamo_client.clone());
+            let matching_repository = DynamoDbMatchingRepository::new(dynamo_client);
+            let disconnect_usecase = DisconnectUseCase::new(
+                Arc::new(connection_repository),
+                Arc::new(matching_repository),
             );
+
+            disconnect_usecase.execute(&connection_id).await.map_err(|e| {
+                tracing::error!(connection_id = %connection_id, error = %e, "Disconnect cleanup failed");
+                Error::from(e)
+            })?;
         }
         "$default" => {
             // メッセージ受信時の処理

--- a/game_server/rust_app/tests/disconnect_matching_integration_test.rs
+++ b/game_server/rust_app/tests/disconnect_matching_integration_test.rs
@@ -1,0 +1,513 @@
+use std::{collections::HashMap, sync::{Arc, Mutex}};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use game_server::{
+    application::{
+        matchmaking::{
+            disconnect_usecase::DisconnectUseCase,
+            matchmaking_application_service::MatchmakingApplicationService,
+            matchmaking_dto::CreateUnitDto,
+        },
+        schedule::schedule_maker::ScheduleMaker,
+        websocket::{websocket_response::WebSocketResponse, websocket_sender::WebSocketSender},
+    },
+    domain::{
+        matching_management::{
+            models::matching::{
+                Matching, MatchingEndDatetime, MatchingStatus, MatchingStatusValue,
+            },
+            repositories::matching_repository::MatchingRepository,
+        },
+        player_management::repositories::connection_repository::ConnectionRepository,
+        triggergame_simulator::{
+            models::{
+                game::{game::Game, game_id::game_id::GameId},
+                turn::turn_number::turn_number::TurnNumber,
+            },
+            repositories::game_repository::GameRepository,
+        },
+        unit_management::{models::unit::Unit, repositories::unit_repository::UnitRepository},
+    },
+};
+
+const PLAYER_A: &str = "550e8400-e29b-41d4-a716-4466554400a1";
+const PLAYER_B: &str = "550e8400-e29b-41d4-a716-4466554400b2";
+const CONN_A1: &str = "conn-a-1";
+const CONN_A2: &str = "conn-a-2";
+const CONN_B: &str = "conn-b";
+
+#[derive(Default)]
+struct InMemoryConnectionRepository {
+    player_to_connection: Mutex<HashMap<String, String>>,
+    connection_to_player: Mutex<HashMap<String, String>>,
+}
+
+#[async_trait]
+impl ConnectionRepository for InMemoryConnectionRepository {
+    async fn save(&self, player_id: &str, connection_id: &str) -> Result<(), String> {
+        let mut player_to_connection = self.player_to_connection.lock().unwrap();
+        let mut connection_to_player = self.connection_to_player.lock().unwrap();
+
+        if let Some(old_connection_id) = player_to_connection.insert(player_id.to_string(), connection_id.to_string()) {
+            connection_to_player.remove(&old_connection_id);
+        }
+        connection_to_player.insert(connection_id.to_string(), player_id.to_string());
+        Ok(())
+    }
+
+    async fn get_connection_id(&self, player_id: &str) -> Result<String, String> {
+        self.player_to_connection
+            .lock()
+            .unwrap()
+            .get(player_id)
+            .cloned()
+            .ok_or_else(|| format!("Connectionが見つかりません: {}", player_id))
+    }
+
+    async fn get_player_id_by_connection_id(
+        &self,
+        connection_id: &str,
+    ) -> Result<Option<String>, String> {
+        Ok(self
+            .connection_to_player
+            .lock()
+            .unwrap()
+            .get(connection_id)
+            .cloned())
+    }
+
+    async fn delete_by_connection_id(&self, connection_id: &str) -> Result<(), String> {
+        let mut player_to_connection = self.player_to_connection.lock().unwrap();
+        let mut connection_to_player = self.connection_to_player.lock().unwrap();
+
+        if let Some(player_id) = connection_to_player.remove(connection_id) {
+            player_to_connection.remove(&player_id);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct InMemoryMatchingRepository {
+    matchings: Mutex<Vec<Matching>>,
+}
+
+impl InMemoryMatchingRepository {
+    fn statuses_for_player1(&self, player_id: &str) -> Vec<MatchingStatusValue> {
+        self.matchings
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|matching| matching.player1_id().value() == player_id)
+            .map(|matching| matching.matching_status().value().clone())
+            .collect()
+    }
+
+    fn has_completed_match_between(&self, player1_id: &str, player2_id: &str) -> bool {
+        self.matchings
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|matching| {
+                matching.player1_id().value() == player1_id
+                    && matching
+                        .player2_id()
+                        .as_ref()
+                        .map(|id| id.value() == player2_id)
+                        .unwrap_or(false)
+                    && matching.matching_status().value() == &MatchingStatusValue::Completed
+            })
+    }
+}
+
+#[async_trait]
+impl MatchingRepository for InMemoryMatchingRepository {
+    async fn save(&self, matching: &Matching) -> Result<(), String> {
+        self.matchings.lock().unwrap().push(matching.clone());
+        Ok(())
+    }
+
+    async fn update(&self, matching: &Matching) -> Result<(), String> {
+        let mut guard = self.matchings.lock().unwrap();
+        if let Some(target) = guard
+            .iter_mut()
+            .find(|item| item.matching_id().value() == matching.matching_id().value())
+        {
+            *target = matching.clone();
+            return Ok(());
+        }
+        Err("matching not found".to_string())
+    }
+
+    async fn get_latest_waiting_matching(&self) -> Result<Option<Matching>, String> {
+        Ok(self
+            .matchings
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|matching| matching.matching_status().value() == &MatchingStatusValue::InProgress)
+            .cloned())
+    }
+
+    async fn interrupt_waiting_by_player_id(&self, player_id: &str) -> Result<(), String> {
+        let mut guard = self.matchings.lock().unwrap();
+        for matching in guard.iter_mut().filter(|matching| {
+            matching.player1_id().value() == player_id
+                && matching.matching_status().value() == &MatchingStatusValue::InProgress
+        }) {
+            *matching = Matching::new(
+                matching.matching_id().clone(),
+                matching.player1_id().clone(),
+                matching.player2_id().clone(),
+                matching.matching_start_datetime().clone(),
+                MatchingEndDatetime::new(Some(Utc::now())),
+                MatchingStatus::new(MatchingStatusValue::Interrupted),
+            );
+        }
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct InMemoryUnitRepository {
+    units: Mutex<Vec<Unit>>,
+}
+
+#[async_trait]
+impl UnitRepository for InMemoryUnitRepository {
+    async fn save(&self, unit: &Unit) -> Result<(), String> {
+        self.units.lock().unwrap().push(unit.clone());
+        Ok(())
+    }
+
+    async fn update(&self, unit: &Unit) -> Result<(), String> {
+        let mut guard = self.units.lock().unwrap();
+        if let Some(target) = guard
+            .iter_mut()
+            .find(|item| item.unit_id().value() == unit.unit_id().value())
+        {
+            *target = unit.clone();
+        }
+        Ok(())
+    }
+
+    async fn update_units(&self, units: &Vec<Unit>) -> Result<(), String> {
+        for unit in units {
+            self.update(unit).await?;
+        }
+        Ok(())
+    }
+
+    async fn get_game_units(&self, game_id: &GameId) -> Result<Vec<Unit>, String> {
+        Ok(self
+            .units
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|unit| unit.game_id().value() == game_id.value())
+            .cloned()
+            .collect())
+    }
+}
+
+#[derive(Default)]
+struct InMemoryGameRepository {
+    games: Mutex<Vec<Game>>,
+}
+
+impl InMemoryGameRepository {
+    fn saved_count(&self) -> usize {
+        self.games.lock().unwrap().len()
+    }
+}
+
+#[async_trait]
+impl GameRepository for InMemoryGameRepository {
+    async fn save(&self, game: &Game) -> Result<(), String> {
+        self.games.lock().unwrap().push(game.clone());
+        Ok(())
+    }
+
+    async fn update(&self, game: &Game) -> Result<(), String> {
+        let mut guard = self.games.lock().unwrap();
+        if let Some(target) = guard
+            .iter_mut()
+            .find(|item| item.game_id().value() == game.game_id().value())
+        {
+            *target = game.clone();
+        }
+        Ok(())
+    }
+
+    async fn get_game_by_id(&self, game_id: &GameId) -> Result<Game, String> {
+        self.games
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|game| game.game_id().value() == game_id.value())
+            .cloned()
+            .ok_or_else(|| "game not found".to_string())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MatchmakingNotification {
+    connection_id: String,
+    status: MatchingStatusValue,
+    game_id: Option<String>,
+}
+
+#[derive(Default)]
+struct CollectingWebSocketSender {
+    notifications: Mutex<Vec<MatchmakingNotification>>,
+}
+
+impl CollectingWebSocketSender {
+    fn contains_status(&self, connection_id: &str, status: MatchingStatusValue) -> bool {
+        self.notifications
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|n| n.connection_id == connection_id && n.status == status)
+    }
+}
+
+#[async_trait]
+impl WebSocketSender for CollectingWebSocketSender {
+    async fn send_message(
+        &self,
+        connection_id: &str,
+        response: &WebSocketResponse,
+    ) -> Result<(), String> {
+        if let WebSocketResponse::MatchmakingResult { status, game_id, .. } = response {
+            self.notifications.lock().unwrap().push(MatchmakingNotification {
+                connection_id: connection_id.to_string(),
+                status: status.clone(),
+                game_id: game_id.clone(),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct NoopScheduleMaker;
+
+#[async_trait]
+impl ScheduleMaker for NoopScheduleMaker {
+    async fn make_schedule_event(
+        &self,
+        _game_id: &GameId,
+        _turn_number: &TurnNumber,
+        _time: &DateTime<Utc>,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+fn create_test_units(seed: &str) -> Vec<CreateUnitDto> {
+    vec![CreateUnitDto {
+        unit_type_id: format!("unit-type-{}", seed),
+        initial_x: 3,
+        initial_y: 4,
+        using_main_trigger_id: format!("main-trigger-{}", seed),
+        using_sub_trigger_id: format!("sub-trigger-{}", seed),
+        main_trigger_ids: vec![format!("main-trigger-{}", seed)],
+        sub_trigger_ids: vec![format!("sub-trigger-{}", seed)],
+    }]
+}
+
+type TestSetup = (
+    Arc<InMemoryConnectionRepository>,
+    Arc<InMemoryMatchingRepository>,
+    Arc<InMemoryGameRepository>,
+    Arc<CollectingWebSocketSender>,
+    MatchmakingApplicationService,
+    DisconnectUseCase,
+);
+
+fn setup() -> TestSetup {
+    let connection_repository = Arc::new(InMemoryConnectionRepository::default());
+    let matching_repository = Arc::new(InMemoryMatchingRepository::default());
+    let game_repository = Arc::new(InMemoryGameRepository::default());
+    let websocket_sender = Arc::new(CollectingWebSocketSender::default());
+
+    let disconnect_usecase = DisconnectUseCase::new(connection_repository.clone(), matching_repository.clone());
+
+    let matchmaking_service = MatchmakingApplicationService::new(
+        matching_repository.clone(),
+        connection_repository.clone(),
+        Arc::new(InMemoryUnitRepository::default()),
+        game_repository.clone(),
+        websocket_sender.clone(),
+        Arc::new(NoopScheduleMaker),
+    );
+
+    (
+        connection_repository,
+        matching_repository,
+        game_repository,
+        websocket_sender,
+        matchmaking_service,
+        disconnect_usecase,
+    )
+}
+
+#[tokio::test]
+async fn acceptance_pattern1_disconnect_then_rejoin_starts_game() {
+    let (
+        connection_repository,
+        matching_repository,
+        game_repository,
+        websocket_sender,
+        matchmaking_service,
+        disconnect_usecase,
+    ) = setup();
+
+    connection_repository.save(PLAYER_A, CONN_A1).await.unwrap();
+    matchmaking_service
+        .execute(PLAYER_A, CONN_A1, create_test_units("a-first"))
+        .await
+        .unwrap();
+
+    disconnect_usecase.execute(CONN_A1).await.unwrap();
+
+    connection_repository.save(PLAYER_B, CONN_B).await.unwrap();
+    matchmaking_service
+        .execute(PLAYER_B, CONN_B, create_test_units("b"))
+        .await
+        .unwrap();
+
+    connection_repository.save(PLAYER_A, CONN_A2).await.unwrap();
+    matchmaking_service
+        .execute(PLAYER_A, CONN_A2, create_test_units("a-rejoin"))
+        .await
+        .unwrap();
+
+    assert!(websocket_sender.contains_status(CONN_A2, MatchingStatusValue::Completed));
+    assert!(websocket_sender.contains_status(CONN_B, MatchingStatusValue::Completed));
+    assert_eq!(game_repository.saved_count(), 1);
+
+    let a_statuses = matching_repository.statuses_for_player1(PLAYER_A);
+    assert!(a_statuses.contains(&MatchingStatusValue::Interrupted));
+}
+
+#[tokio::test]
+async fn acceptance_pattern2_refresh_disconnect_connect_then_game_starts() {
+    let (
+        connection_repository,
+        matching_repository,
+        game_repository,
+        websocket_sender,
+        matchmaking_service,
+        disconnect_usecase,
+    ) = setup();
+
+    connection_repository.save(PLAYER_A, CONN_A1).await.unwrap();
+    matchmaking_service
+        .execute(PLAYER_A, CONN_A1, create_test_units("a-before-refresh"))
+        .await
+        .unwrap();
+
+    disconnect_usecase.execute(CONN_A1).await.unwrap();
+
+    connection_repository.save(PLAYER_A, CONN_A2).await.unwrap();
+    matchmaking_service
+        .execute(PLAYER_A, CONN_A2, create_test_units("a-after-refresh"))
+        .await
+        .unwrap();
+
+    connection_repository.save(PLAYER_B, CONN_B).await.unwrap();
+    matchmaking_service
+        .execute(PLAYER_B, CONN_B, create_test_units("b"))
+        .await
+        .unwrap();
+
+    assert!(websocket_sender.contains_status(CONN_A2, MatchingStatusValue::Completed));
+    assert!(websocket_sender.contains_status(CONN_B, MatchingStatusValue::Completed));
+    assert_eq!(game_repository.saved_count(), 1);
+
+    let a_statuses = matching_repository.statuses_for_player1(PLAYER_A);
+    assert!(a_statuses.contains(&MatchingStatusValue::Interrupted));
+    assert!(a_statuses.contains(&MatchingStatusValue::Completed));
+}
+
+#[tokio::test]
+async fn disconnect_during_waiting_interrupts_matching() {
+    let (
+        connection_repository,
+        matching_repository,
+        _game_repository,
+        _websocket_sender,
+        matchmaking_service,
+        disconnect_usecase,
+    ) = setup();
+
+    connection_repository.save(PLAYER_A, CONN_A1).await.unwrap();
+    matchmaking_service
+        .execute(PLAYER_A, CONN_A1, create_test_units("a"))
+        .await
+        .unwrap();
+
+    disconnect_usecase.execute(CONN_A1).await.unwrap();
+
+    let a_statuses = matching_repository.statuses_for_player1(PLAYER_A);
+    assert!(a_statuses.contains(&MatchingStatusValue::Interrupted));
+    assert!(connection_repository
+        .get_player_id_by_connection_id(CONN_A1)
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn disconnect_when_not_matching_is_noop() {
+    let (
+        _connection_repository,
+        matching_repository,
+        _game_repository,
+        _websocket_sender,
+        _matchmaking_service,
+        disconnect_usecase,
+    ) = setup();
+
+    disconnect_usecase.execute("unknown-connection").await.unwrap();
+
+    assert!(matching_repository
+        .statuses_for_player1(PLAYER_A)
+        .is_empty());
+    assert!(matching_repository
+        .statuses_for_player1(PLAYER_B)
+        .is_empty());
+}
+
+#[tokio::test]
+async fn completion_is_not_overwritten_by_disconnect_interruption() {
+    let (
+        connection_repository,
+        matching_repository,
+        _game_repository,
+        websocket_sender,
+        matchmaking_service,
+        disconnect_usecase,
+    ) = setup();
+
+    connection_repository.save(PLAYER_A, CONN_A1).await.unwrap();
+    matchmaking_service
+        .execute(PLAYER_A, CONN_A1, create_test_units("a"))
+        .await
+        .unwrap();
+
+    connection_repository.save(PLAYER_B, CONN_B).await.unwrap();
+    matchmaking_service
+        .execute(PLAYER_B, CONN_B, create_test_units("b"))
+        .await
+        .unwrap();
+
+    disconnect_usecase.execute(CONN_A1).await.unwrap();
+
+    assert!(matching_repository.has_completed_match_between(PLAYER_A, PLAYER_B));
+    assert!(websocket_sender.contains_status(CONN_A1, MatchingStatusValue::Completed));
+    assert!(websocket_sender.contains_status(CONN_B, MatchingStatusValue::Completed));
+}

--- a/game_server/template.yaml
+++ b/game_server/template.yaml
@@ -57,7 +57,7 @@ Resources:
               - !GetAtt MatchingsTable.Arn
               - !Sub '${MatchingsTable.Arn}/index/*'
               - !GetAtt ConnectionsTable.Arn
-              # - !Sub '${ConnectionsTable.Arn}/index/*' グローバルセカンダリインデックスは無いのでコメントアウト
+              - !Sub '${ConnectionsTable.Arn}/index/*'
               - !GetAtt UnitsTable.Arn
               - !Sub '${UnitsTable.Arn}/index/*'
               - !GetAtt GamesTable.Arn
@@ -261,9 +261,18 @@ Resources:
         # プライマリキーを player_id に設定することで、一意のプレイヤーに対して最新の接続IDを保存できる
         - AttributeName: player_id
           AttributeType: S
+        - AttributeName: connection_id
+          AttributeType: S
       KeySchema:
         - AttributeName: player_id
           KeyType: HASH
+      GlobalSecondaryIndexes:
+        - IndexName: ConnectionIdIndex
+          KeySchema:
+            - AttributeName: connection_id
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
       BillingMode: PAY_PER_REQUEST
 
 

--- a/local-dynamodb-initialize/main.go
+++ b/local-dynamodb-initialize/main.go
@@ -96,10 +96,20 @@ func createTables(ctx context.Context, client *dynamodb.Client) error {
 		TableName: aws.String("Connections"),
 		AttributeDefinitions: []types.AttributeDefinition{
 			{AttributeName: aws.String("player_id"), AttributeType: types.ScalarAttributeTypeS},
+			{AttributeName: aws.String("connection_id"), AttributeType: types.ScalarAttributeTypeS},
 		},
 		KeySchema: []types.KeySchemaElement{
 			// プライマリキーを player_id に設定することで、一意のプレイヤーに対して最新の接続IDを保存できる
 			{AttributeName: aws.String("player_id"), KeyType: types.KeyTypeHash},
+		},
+		GlobalSecondaryIndexes: []types.GlobalSecondaryIndex{
+			{
+				IndexName: aws.String("ConnectionIdIndex"),
+				KeySchema: []types.KeySchemaElement{
+					{AttributeName: aws.String("connection_id"), KeyType: types.KeyTypeHash},
+				},
+				Projection: &types.Projection{ProjectionType: types.ProjectionTypeAll},
+			},
 		},
 		BillingMode: types.BillingModePayPerRequest,
 	})

--- a/local-websocket-apigateway/main.go
+++ b/local-websocket-apigateway/main.go
@@ -50,15 +50,20 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	}
 	defer func() {
 		conn.Close()
-		// 接続を削除
+		// 接続を削除し、connection_id を取得して $disconnect を Lambda に通知
 		clientsMu.Lock()
+		var disconnectedId string
 		for id, c := range clients {
 			if c == conn {
+				disconnectedId = id
 				delete(clients, id)
 				break
 			}
 		}
 		clientsMu.Unlock()
+		if disconnectedId != "" {
+			invokeDisconnect(disconnectedId)
+		}
 	}()
 
 	for {
@@ -127,6 +132,42 @@ func handlePostToConnection(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
+}
+
+func invokeDisconnect(connectionId string) {
+	client := &http.Client{}
+
+	lambdaEvent := map[string]interface{}{
+		"requestContext": map[string]interface{}{
+			"connectionId": connectionId,
+			"routeKey":     "$disconnect",
+			"domainName":   "localhost",
+			"stage":        "local",
+		},
+		"body": "",
+	}
+
+	payload, err := json.Marshal(lambdaEvent)
+	if err != nil {
+		log.Printf("Disconnect marshal error: %v", err)
+		return
+	}
+
+	lambdaURL := "http://game-server:9000/2015-03-31/functions/game_server/invocations"
+	req, err := http.NewRequest("POST", lambdaURL, bytes.NewBuffer(payload))
+	if err != nil {
+		log.Printf("Disconnect request creation error: %v", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Printf("Disconnect Lambda invocation error: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+	log.Printf("Disconnect Lambda response status: %d (connectionId=%s)", resp.StatusCode, connectionId)
 }
 
 func invokeLambda(msg Message) map[string]interface{} {

--- a/local-websocket-apigateway/main.go
+++ b/local-websocket-apigateway/main.go
@@ -134,6 +134,8 @@ func handlePostToConnection(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+// invokeDisconnect は WebSocket 切断時に Lambda へ $disconnect イベントを送信する。
+// これにより game_server 側の切断後処理（待機中断・接続削除）をローカルでも再現できる。
 func invokeDisconnect(connectionId string) {
 	client := &http.Client{}
 
@@ -170,6 +172,7 @@ func invokeDisconnect(connectionId string) {
 	log.Printf("Disconnect Lambda response status: %d (connectionId=%s)", resp.StatusCode, connectionId)
 }
 
+// invokeLambda は通常の受信メッセージを $default ルートイベントとして Lambda に転送する。
 func invokeLambda(msg Message) map[string]interface{} {
 	client := &http.Client{}
 


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記載 -->

## 関連Issue

- Closes #69 

## 変更内容

- 切断時にマッチングを終了する処理を作成
- リポジトリクラス、applicationクラスにテスト追加
- コネクションIDのグローバルセカンダリインデックスを追加

## 動作確認

### 確認環境

- [x] local
- [x] dev

### 手順

1. プレイヤーAがマッチングを開始する
2. プレイヤーAがタブを消す
3. プレイヤーBがマッチングを開始する
4. プレイヤーAがマッチングを開始する
5. ゲームが開始される

### 結果

- [x] 期待通りに動作する
- [x] 既存機能へ副作用がないことを確認した

## 影響範囲

- [ ] game-client
- [x] game_server
- [x] local-websocket-apigateway
- [x] local-dynamodb-initialize
- [ ] local-eventbridge-scheduler
- [ ] ドキュメントのみ

## テスト

- [x] 追加/変更した処理に対して必要なテストを実施した
- [ ] 手動確認のみ（理由を下に記載）

手動確認理由（必要時）:

## UI変更（必要時）

- スクリーンショット or 動画を添付

## レビュー観点（任意）

<!-- 特に見てほしい点があれば記載 -->

## チェックリスト

- [x] ブランチ名が規約に沿っている（`feature/*`, `fix/*`, `chore/*`, `docs/*`）
- [x] PRタイトルが規約に沿っている（`<type>: <概要> (#issue番号)`）
- [x] 1PR1目的になっている
- [x] 不要な差分（無関係な整形/リネーム等）がない
- [ ] 破壊的変更がある場合、内容と移行手順を記載した

## 備考

上記はあくまで推奨ルールです。従わなくても全然いいですが、迷ったら参考にしてください。
