### PR TITLE
fix: トリガーエリア内に入っても戦闘が発生しない問題の修正（#74）

### DIFF
--- a/game_server/rust_app/src/domain/triggergame_simulator/models/combat/combat.rs
+++ b/game_server/rust_app/src/domain/triggergame_simulator/models/combat/combat.rs
@@ -126,7 +126,7 @@ impl Combat {
         );
         // 攻撃側側から見て防御側が見えているか確認
         let is_defender_visible =
-            visibility.check_units_visibility(&attacker_position, &defender_position);
+            visibility.check_combat_visibility(&attacker_position, &defender_position);
         if (!is_main_trigger_hit && !is_sub_trigger_hit) || !is_defender_visible {
             // 射程外 かつ 角度の範囲外　または 視界外の場合はNoneを返す
             return None;

--- a/game_server/rust_app/src/domain/triggergame_simulator/models/combat/combat_test.rs
+++ b/game_server/rust_app/src/domain/triggergame_simulator/models/combat/combat_test.rs
@@ -25,34 +25,37 @@ mod tests {
     }
 
     fn create_test_visiblity() -> Visibility {
-        Visibility::new(vec![vec![0; 10]; 10])
+        Visibility::create()
     }
 
+    /// ポジションはcombat内で反転されるので攻撃側から見た位置と防御側から見た位置をそれぞれ設定する
+    /// シューターが画面左上で後ろ向きにトリガーを向けて攻撃（同じ階層）
     #[test]
-    fn test_create_combat_returns_option() {
+    fn test_create_combat_shooter() {
         let mut visibility = create_test_visiblity();
         let combat = Combat::create(
             create_test_unit_id(),
-            create_test_position(),
-            create_test_trigger_id(),
-            create_test_trigger_id(),
-            create_test_trigger_azimuth(),
-            create_test_trigger_azimuth(),
+            Position::new(14, 9),
+            TriggerId::new("ASTEROID".to_string()),
+            TriggerId::new("ASTEROID".to_string()),
+            TriggerAzimuth::new(180),
+            TriggerAzimuth::new(180),
             10,
             create_test_unit_id(),
-            Position::new(100, 100),
-            create_test_trigger_id(),
-            create_test_trigger_id(),
+            Position::new(21, 22),
+            TriggerId::new("IBIS".to_string()),
+            TriggerId::new("BAGWORM".to_string()),
             100,
             100,
-            create_test_trigger_azimuth(),
-            create_test_trigger_azimuth(),
+            TriggerAzimuth::new(0),
+            TriggerAzimuth::new(0),
             5,
             2,
             &mut visibility,
         );
+        println!("Combat creation result: {:?}", combat);
 
-        // Combatの生成に成功するか（射程や角度等の条件により失敗する可能性あり）
-        assert!(combat.is_some() || combat.is_none());
+        // Combatの生成に成功するか
+        assert!(combat.is_some());
     }
 }

--- a/game_server/rust_app/src/domain/triggergame_simulator/models/game/visibility.rs
+++ b/game_server/rust_app/src/domain/triggergame_simulator/models/game/visibility.rs
@@ -25,8 +25,18 @@ impl Visibility {
         &self.field_steps
     }
 
+    /// 攻撃者から防御者が見えるかを判定する関数
+    /// 関数内で防御者の座標を反転させて視界範囲チェックを行う
+    pub fn check_combat_visibility(
+        &self,
+        attacker_pos: &Position,
+        defender_pos: &Position,
+    ) -> bool {
+        self.check_units_visibility(attacker_pos, &defender_pos.get_enemy_position())
+    }
+
     /// ポジションAからポジションBが見えるか計算し、見える場合はtrueを返す
-    pub fn check_units_visibility(&self, position_a: &Position, position_b: &Position) -> bool {
+    fn check_units_visibility(&self, position_a: &Position, position_b: &Position) -> bool {
         if position_a.col() == position_b.col() && position_a.row() == position_b.row() {
             // 同じ位置は常に見える
             return true;


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記載 -->

## 関連Issue

- Closes #74 

## 変更内容

- Combatテストコードの更新
- 攻撃者から防御者が見えているかのチェックを、敵の座標を反転させるよう修正

## 動作確認

### 確認環境

- [x] local
- [ ] dev

### 手順

1. ゲーム開始する
2. プレイヤーAから見た(14, 9)の位置に修を移動させる
3. ６時の方向にトリガーを向ける
4. プレイヤーBから見た(21, 22)の位置に千佳を移動させる
5. 12時の方向にトリガーを向ける

### 結果

- [x] 期待通りに動作する
- [x] 既存機能へ副作用がないことを確認した

## 影響範囲

- [ ] game-client
- [x] game_server
- [ ] local-websocket-apigateway
- [ ] local-dynamodb-initialize
- [ ] local-eventbridge-scheduler
- [ ] ドキュメントのみ

## テスト

- [x] 追加/変更した処理に対して必要なテストを実施した
- [ ] 手動確認のみ（理由を下に記載）

手動確認理由（必要時）:

## UI変更（必要時）

- スクリーンショット or 動画を添付

## レビュー観点（任意）

<!-- 特に見てほしい点があれば記載 -->

## チェックリスト

- [x] ブランチ名が規約に沿っている（`feature/*`, `fix/*`, `chore/*`, `docs/*`）
- [x] PRタイトルが規約に沿っている（`<type>: <概要> (#issue番号)`）
- [x] 1PR1目的になっている
- [x] 不要な差分（無関係な整形/リネーム等）がない
- [ ] 破壊的変更がある場合、内容と移行手順を記載した

## 備考

上記はあくまで推奨ルールです。従わなくても全然いいですが、迷ったら参考にしてください。
