### PR TITLE
feat: マッチングキャンセル機能の実装 (#68)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,15 @@ DynamoDBのローカル版はdocker compose内で `amazon/dynamodb-local:latest`
 
 ### 本番環境
 
+mainブランチにマージされたコードは以下のURLで公開しています
+
 [本番環境ページリンク](https://main.dsxdacl6jlb8y.amplifyapp.com/)
+
+### 開発環境
+
+developブランチにマージされたコードは以下のURLで公開しています
+
+[開発環境ページリンク](https://develop.dsxdacl6jlb8y.amplifyapp.com/)
 
 ### ゲームの基本的なルール・設計
 

--- a/docs/03_詳細設計/API設計書/asyncapi.yaml
+++ b/docs/03_詳細設計/API設計書/asyncapi.yaml
@@ -156,8 +156,6 @@ components:
           action:
             type: string
             enum: [cancelMatching]
-          playerId:
-            type: string
 
     MatchmakingResult:
       name: matchmakingResult

--- a/game-client/app/lobby/page.tsx
+++ b/game-client/app/lobby/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import RotateView from '@/components/views/RotateView';
 import { useManageMatching } from './useManageMatching';
-import Link from 'next/link';
 
 /**
  * マッチング待機中ページコンポーネント
@@ -71,20 +70,7 @@ export default function LobbyPage() {
               マッチングをキャンセル
             </button>
           )}
-
-          <Link
-            href="/"
-            className="w-full bg-gray-600 hover:bg-gray-700 text-white py-3 px-6 rounded-lg transition-colors"
-          >
-            ホームに戻る
-          </Link>
         </div>
-
-        {/* デバッグ情報（開発時のみ） */}
-        {process.env.NODE_ENV === "development" && (
-          <div className="mt-6 text-left bg-black/20 rounded-lg p-3 text-xs text-white/50 font-mono">
-          </div>
-        )}
       </div>
     </div>
   );

--- a/game-client/app/lobby/useManageMatching.tsx
+++ b/game-client/app/lobby/useManageMatching.tsx
@@ -124,10 +124,9 @@ export const useManageMatching = () => {
 
   // マッチングキャンセル
   const cancelMatching = () => {
-    // sendMessage({
-    //   action: "cancel_matching",
-    //   playerId: playerId || undefined,
-    // });
+    sendMessage({
+      action: "cancelMatching",
+    });
     router.push("/");
   };
 

--- a/game-client/contexts/types/WebSocketRequests.ts
+++ b/game-client/contexts/types/WebSocketRequests.ts
@@ -20,6 +20,13 @@ interface MatchMakingRequest {
 }
 
 /**
+ * マッチングキャンセルリクエストの型定義
+ */
+interface CancelMatchingRequest {
+  action: "cancelMatching";
+}
+
+/**
  * ゲーム情報取得リクエストの型定義
  */
 interface GetGameStateRequest {
@@ -36,11 +43,5 @@ interface TurnActionsRequest {
   steps: Step[];
 };
 
-/** ゲームのキャンセル時に送信するリクエストの型定義 */
-interface CancelGameRequest {
-  action: "cancelMatching";
-  playerId: string;
-}
-
 /** WebSocketリクエストの型 */
-export type WebSocketRequestType = MatchMakingRequest | GetGameStateRequest | TurnActionsRequest | CancelGameRequest;
+export type WebSocketRequestType = MatchMakingRequest | CancelMatchingRequest | GetGameStateRequest | TurnActionsRequest;

--- a/game_server/rust_app/src/application/websocket/websocket_request.rs
+++ b/game_server/rust_app/src/application/websocket/websocket_request.rs
@@ -36,6 +36,10 @@ pub enum WebSocketRequest {
         units: Vec<CreateUnitDto>,
     },
 
+    /// マッチングキャンセルリクエスト
+    /// マッチング待機中のプレイヤーがマッチングをキャンセルするために送信される
+    CancelMatching {},
+
     /// ゲーム状態取得リクエスト
     /// ゲーム画面に遷移したときにクライアントから送信される
     GetGameState {

--- a/game_server/rust_app/src/main.rs
+++ b/game_server/rust_app/src/main.rs
@@ -226,6 +226,23 @@ async fn handle_websocket_event(event: WebSocketEvent) -> Result<Response, Error
                             .await?;
                     }
 
+                    // マッチングキャンセルリクエストの処理
+                    WebSocketRequest::CancelMatching {} => {
+                        let connection_id = &event.request_context.connection_id;
+                        // マッチングリポジトリとサービスの作成
+                        let matching_repository =
+                            DynamoDbMatchingRepository::new(dynamo_client.clone());
+                        let disconnect_usecase = DisconnectUseCase::new(
+                            Arc::new(connection_repository),
+                            Arc::new(matching_repository),
+                        );
+
+                        disconnect_usecase.execute(connection_id).await.map_err(|e| {
+                            tracing::error!(connection_id = %connection_id, error = %e, "マッチングのキャンセルに失敗しました");
+                            Error::from(e)
+                        })?;
+                    }
+
                     // ゲーム状態取得リクエストの処理
                     WebSocketRequest::GetGameState { player_id, game_id } => {
                         // コネクションIDとPlayerIDの紐付けを保存

--- a/local-websocket-apigateway/go.mod
+++ b/local-websocket-apigateway/go.mod
@@ -2,4 +2,7 @@ module websocket-gateway
 
 go 1.25
 
-require github.com/gorilla/websocket v1.5.3
+require (
+	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.3
+)

--- a/local-websocket-apigateway/go.sum
+++ b/local-websocket-apigateway/go.sum
@@ -1,2 +1,4 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/local-websocket-apigateway/main.go
+++ b/local-websocket-apigateway/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 )
 
@@ -48,21 +49,21 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		log.Println("Upgrade error:", err)
 		return
 	}
+
+	// API Gateway 相当の接続IDを接続時に払い出し、接続ライフサイクル中は固定で使う。
+	connectionID := uuid.NewString()
+	clientsMu.Lock()
+	clients[connectionID] = conn
+	clientsMu.Unlock()
+
 	defer func() {
 		conn.Close()
 		// 接続を削除し、connection_id を取得して $disconnect を Lambda に通知
 		clientsMu.Lock()
-		var disconnectedId string
-		for id, c := range clients {
-			if c == conn {
-				disconnectedId = id
-				delete(clients, id)
-				break
-			}
-		}
+		delete(clients, connectionID)
 		clientsMu.Unlock()
-		if disconnectedId != "" {
-			invokeDisconnect(disconnectedId)
+		if connectionID != "" {
+			invokeDisconnect(connectionID)
 		}
 	}()
 
@@ -76,13 +77,8 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		// 受信したメッセージのログ出力
 		// log.Printf("Received: %+v\n", msg)
 
-		// 接続を登録（connection_id として player_id を使用）
-		clientsMu.Lock()
-		clients[msg.PlayerId] = conn
-		clientsMu.Unlock()
-
 		// Lambda を呼び出し
-		response := invokeLambda(msg)
+		response := invokeLambda(connectionID, msg)
 
 		// クライアントに返信（Lambda からの POST で送信されるため、ここでは不要）
 		_ = response
@@ -173,7 +169,7 @@ func invokeDisconnect(connectionId string) {
 }
 
 // invokeLambda は通常の受信メッセージを $default ルートイベントとして Lambda に転送する。
-func invokeLambda(msg Message) map[string]interface{} {
+func invokeLambda(connectionID string, msg Message) map[string]interface{} {
 	client := &http.Client{}
 
 	// bodyを文字列化
@@ -186,7 +182,7 @@ func invokeLambda(msg Message) map[string]interface{} {
 	// Lambda Runtime API の形式に合わせる
 	lambdaEvent := map[string]interface{}{
 		"requestContext": map[string]interface{}{
-			"connectionId": msg.PlayerId,
+			"connectionId": connectionID,
 			"routeKey":     "$default",
 			"domainName":   "localhost",
 			"stage":        "local",


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記載 -->
マッチングキャンセル機能を実装しました。
ボタンはすでにあるのでwebsocketメッセージ処理を実装しました

## 関連Issue

- Closes #68 

## 変更内容

- API設計書の更新
- 「ホームに戻る」のボタンは不要なので除去
- cancelMatchingのメッセージ処理を追加

## 動作確認

### 確認環境

- [x] local
- [ ] dev

### 手順

1. プレイヤーAでマッチングを開始する
2. マッチングキャンセルボタンを押下する
3. プレイヤーBでマッチングを開始する
4. **マッチングされないことを確認する**
5. プレイヤーAでマッチングを開始する
6. **マッチングされることを確認する**

### 結果

- [x] 期待通りに動作する
- [x] 既存機能へ副作用がないことを確認した

## 影響範囲

- [x] game-client
- [x] game_server
- [ ] local-websocket-apigateway
- [ ] local-dynamodb-initialize
- [ ] local-eventbridge-scheduler
- [ ] ドキュメントのみ

## テスト

- [ ] 追加/変更した処理に対して必要なテストを実施した
- [x] 手動確認のみ（理由を下に記載）

手動確認理由（必要時）: マッチングキャンセル処理の中身は別チケットで作成済みのため、UI確認のみ

## UI変更（必要時）

- スクリーンショット or 動画を添付

<img width="785" height="549" alt="image" src="https://github.com/user-attachments/assets/b0ce5068-868d-4db9-8d49-c334b3ec2831" />

## レビュー観点（任意）

<!-- 特に見てほしい点があれば記載 -->

## チェックリスト

- [x] ブランチ名が規約に沿っている（`feature/*`, `fix/*`, `chore/*`, `docs/*`）
- [x] PRタイトルが規約に沿っている（`<type>: <概要> (#issue番号)`）
- [x] 1PR1目的になっている
- [x] 不要な差分（無関係な整形/リネーム等）がない
- [ ] 破壊的変更がある場合、内容と移行手順を記載した

## 備考

上記はあくまで推奨ルールです。従わなくても全然いいですが、迷ったら参考にしてください。
