### PR TITLE
fix: スマホで縦向きのままゲーム開始しないようにする (#77)

### DIFF
--- a/game-client/app/lobby/useManageMatching.tsx
+++ b/game-client/app/lobby/useManageMatching.tsx
@@ -1,16 +1,22 @@
 "use client";
 import { WebSocketResponseType } from "@/contexts/types/WebSocketResponses";
 import { useWebSocket } from "@/contexts/WebSocketContext";
+import useDeviceOrientation from "@/hooks/device/useDeviceOrientation";
 import { MatchingStatus } from "@/types/MatchingTypes";
 import { useRouter } from "next/navigation";
 import { useState, useEffect } from "react";
 
 /**
  * マッチング管理用のカスタムフック
+ * 
+ * モバイル端末で縦画面でマッチング中のとき -> マッチング開始をキャンセルする
+ * 接続していないとき -> Websocket接続を開始する
+ * 接続中でモバイル縦画面でないとき -> マッチング開始メッセージを送信する
+ * マッチング結果の受信 -> ステータスを更新してゲーム画面に遷移
  */
 export const useManageMatching = () => {
   const router = useRouter();
-  const [matchingStatus, setMatchingStatus] = useState<MatchingStatus>("InProgress");
+  const [matchingStatus, setMatchingStatus] = useState<MatchingStatus>("NotStarted");
 
   const {
     isConnected,
@@ -64,10 +70,14 @@ export const useManageMatching = () => {
     };
   }, [addMessageListener, removeMessageListener, router]);
 
+
+  const { isMobilePortrait } = useDeviceOrientation();
+
   // マッチング開始
   useEffect(() => {
-    console.log("マッチング開始のチェック:", isConnected);
-    if (isConnected) {
+    console.log(`マッチング開始のチェック: isConnected=${isConnected}, playerId=${playerId}, isMobilePortrait=${isMobilePortrait}`);
+    if (isConnected && !isMobilePortrait && matchingStatus === "NotStarted") {
+      // 接続状態かつモバイル縦向きでない場合にマッチング開始
       if (!playerId) {
         console.error("プレイヤーIDが存在しません。マッチングを開始できません。");
         return;
@@ -115,19 +125,32 @@ export const useManageMatching = () => {
           }
         ],
       });
+      setMatchingStatus("InProgress");
       console.log("マッチング開始メッセージを送信しました");
-    } else {
+
+    } else if (isMobilePortrait && matchingStatus === "InProgress") {
+      // モバイル縦向きかつ接続中の場合、マッチングをキャンセルしてステータスをリセット
+      sendCancelMatching();
+      setMatchingStatus("NotStarted");
+
+    } else if (!isConnected) {
       // 接続していない場合は接続を開始
       connect();
+      setMatchingStatus("NotStarted");
     }
-  }, [isConnected, playerId]); // readyStateの変更時およびplayerIdの変更時に実行
+  }, [isConnected, playerId, isMobilePortrait]); // readyStateの変更時およびplayerIdの変更時に実行
 
   // マッチングキャンセル
   const cancelMatching = () => {
+    sendCancelMatching();
+    router.push("/");
+  };
+
+  /** マッチングキャンセル送信処理 */
+  const sendCancelMatching = () => {
     sendMessage({
       action: "cancelMatching",
     });
-    router.push("/");
   };
 
   // 再接続ボタン

--- a/game-client/app/page.tsx
+++ b/game-client/app/page.tsx
@@ -3,7 +3,6 @@ import { Noto_Sans_JP, Orbitron } from "next/font/google";
 import styles from "./index.module.css";
 import { SkyOutlineButton } from "@/components/buttons/sky-outline";
 import { WhiteFillButton } from "@/components/buttons/white-fill";
-import RotateView from "@/components/views/RotateView";
 
 const orbitron = Orbitron({
   subsets: ["latin"],
@@ -18,9 +17,6 @@ const notoSansJp = Noto_Sans_JP({
 export default function TopPage() {
   return (
     <main className={`${styles.page} ${notoSansJp.className}`}>
-      {/* 画面回転を推奨するコンポーネント */}
-      <RotateView />
-
       <section className={styles.heroSection}>
         <div className={styles.heroContent}>
           <Image

--- a/game-client/components/views/RotateView.tsx
+++ b/game-client/components/views/RotateView.tsx
@@ -1,6 +1,6 @@
 "use client";
+import useDeviceOrientation from "@/hooks/device/useDeviceOrientation";
 import { Metadata } from "next";
-import { useEffect, useState } from "react";
 
 export const metadata: Metadata = {
   viewport: {
@@ -15,38 +15,11 @@ export const metadata: Metadata = {
 
 /**
  * 画面の回転を推奨する表示を行うコンポーネント
- * @returns 
+ * @returns JSX.Element | null
  */
 export default function Index() {
-  const [isMobile, setIsMobile] = useState(false);
-  const [isPortrait, setIsPortrait] = useState(false);
 
-  useEffect(() => {
-    const checkDevice = () => {
-      const mobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
-      setIsMobile(mobile);
-    };
-
-    const checkOrientation = () => {
-      if (isMobile) {
-        const portrait = window.innerHeight > window.innerWidth;
-        setIsPortrait(portrait);
-      }
-    };
-
-    checkDevice();
-    checkOrientation();
-
-    window.addEventListener('resize', checkOrientation);
-    window.addEventListener('orientationchange', () => {
-      setTimeout(checkOrientation, 100); // orientationchange後の遅延
-    });
-
-    return () => {
-      window.removeEventListener('resize', checkOrientation);
-      window.removeEventListener('orientationchange', checkOrientation);
-    };
-  }, [isMobile]);
+  const { isMobilePortrait } = useDeviceOrientation();
 
   // フルスクリーン＋画面回転制御
   const enterFullscreenLandscape = async () => {
@@ -66,7 +39,7 @@ export default function Index() {
     }
   };
 
-  if (isMobile && isPortrait) {
+  if (isMobilePortrait) {
     return (
       <div className="fixed inset-0 z-50 bg-gradient-to-br from-gray-900 to-black flex items-center justify-center">
         <div className="text-center text-white p-8 max-w-sm">
@@ -84,8 +57,9 @@ export default function Index() {
 
           <h2 className="text-3xl font-bold mb-4">画面を横向きにしてください</h2>
           <p className="text-lg text-gray-300 mb-8 leading-relaxed">
-            TriggerAppは横画面でのプレイを<br />
-            推奨しています
+            ワールドトリガーGridFieldは
+            <br />
+            横画面でのプレイを推奨しています
           </p>
 
           <button
@@ -102,4 +76,5 @@ export default function Index() {
       </div>
     );
   }
+  return null;
 }

--- a/game-client/game-logics/GameGrid.tsx
+++ b/game-client/game-logics/GameGrid.tsx
@@ -41,7 +41,6 @@ const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnit
 
   // ゲームを表示するDOMコンテナのRef
   const containerRef = useRef<HTMLDivElement>(null);
-  const resultDialogRef = useRef<HTMLDialogElement>(null);
 
   // ゲームモードの状態管理
   const [gameMode, setGameMode] = useState<"lab" | "execute">("lab");
@@ -111,10 +110,11 @@ const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnit
   };
 
   /** ユニットの行動終了処理 */
-  const handleFinishMotionExecute = () => {
+  const handleFinishMotionExecute = (turnNumber: number) => {
     console.log("ユニットの行動終了処理を実行します。,現在のターン状態:", currentTurn);
     if (currentTurn < MAX_TURN) {
       // 次のターンの動きの設定フェーズへ移行
+      setCurrentTurn(turnNumber + 1);
       setGameMode("lab");
       motionLabDialogRef.current?.show();
     }
@@ -143,7 +143,6 @@ const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnit
         const hydratedTurn = Turn.fromJSON(data.turn);
         targetScene.executeTurn(hydratedTurn, new Date(data.motionLabEndTime)); // Phaserシーンにターン情報を渡して実行
         setGameMode("execute");
-        setCurrentTurn(data.turn.getTurnNumber());
         motionExecuteDialogRef.current?.show();
         setMotionExecuteEndTimeState(new Date(Date.now() + 15000 + 2000)); // 動きの実行時間（15秒）＋αを設定
         setMotionLabEndTimeState(new Date(data.motionLabEndTime));

--- a/game-client/game-logics/phaser/scenes/GridCellsScene.ts
+++ b/game-client/game-logics/phaser/scenes/GridCellsScene.ts
@@ -55,7 +55,7 @@ export class GridCellsScene extends Phaser.Scene {
   private isDraggingTrigger: boolean = false; // トリガー扇形をドラッグ中かどうか
   private currentTriggerAngle: number = 0; // 現在のトリガー角度
 
-  constructor(private firstMotionLabEndtime: Date, private friendUnits: FriendUnit[], private enemyUnits: EnemyUnit[], private fieldSteps: number[][], private visibility: boolean[][], private sendServerTurn: (steps: Step[]) => void, private completeGame: (friendUnits: FriendUnit[], enemyUnits: EnemyUnit[], result: GameResult) => void, private handleFinishMotionExecute: () => void) {
+  constructor(private firstMotionLabEndtime: Date, private friendUnits: FriendUnit[], private enemyUnits: EnemyUnit[], private fieldSteps: number[][], private visibility: boolean[][], private sendServerTurn: (steps: Step[]) => void, private completeGame: (friendUnits: FriendUnit[], enemyUnits: EnemyUnit[], result: GameResult) => void, private handleFinishMotionExecute: (turnNumber: number) => void) {
     super({ key: "GridScene" });
     console.log("GridCellsSceneコンストラクタ: friendUnits =", friendUnits, "enemyUnits =", enemyUnits);
   }
@@ -342,8 +342,8 @@ export class GridCellsScene extends Phaser.Scene {
       scene: this,
       hexUtils: this.hexUtils,
       characterManager: this.characterManager,
-      onReplayCompleted: () => {
-        this.handleFinishMotionExecute();
+      onReplayCompleted: (turnNumber: number) => {
+        this.handleFinishMotionExecute(turnNumber);
       },
       clearTriggerArrows: () => {
         this.triggerArrows.forEach((arrow) => arrow.destroy());

--- a/game-client/game-logics/phaser/scenes/controllers/TurnReplayController.ts
+++ b/game-client/game-logics/phaser/scenes/controllers/TurnReplayController.ts
@@ -79,8 +79,6 @@ export class TurnReplayController {
         // 未再生ステップが残っている場合: 次ステップ再生へ進む。
         this.executeStep(turn, nextStepIndex);
       } else {
-        // 全ステップ再生済みの場合: フェーズ完了処理へ進む。
-        this.completeUnitActionPhase(turn.getTurnNumber());
         console.log("=== 全ステップ実行完了 ===");
         // ゲーム終了判定を行う。
         const gameResult = this.checkGameIsCompleted(turn.getTurnNumber());
@@ -88,7 +86,9 @@ export class TurnReplayController {
           console.log("ゲーム終了判定: 結果 =", gameResult);
           // ゲーム終了処理をここに追加する（例: 結果画面への遷移）
           this.deps.completeGame?.(gameResult);
-          return;
+        } else {
+          // 全ステップ再生済みの場合: フェーズ完了処理へ進む。
+          this.completeUnitActionPhase(turn.getTurnNumber());
         }
       }
     });

--- a/game-client/hooks/device/useDeviceOrientation.ts
+++ b/game-client/hooks/device/useDeviceOrientation.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+
+/**
+ * カスタムフック: デバイスの向きとモバイル判定
+ * @returns isMobilePortrait: モバイルデバイスかつ縦向きかどうか
+ */
+export default function useDeviceOrientation() {
+  const [isMobile, setIsMobile] = useState(false);
+  const [isPortrait, setIsPortrait] = useState(false);
+
+  useEffect(() => {
+    const checkDevice = () => {
+      const mobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+      setIsMobile(mobile);
+    };
+
+    const checkOrientation = () => {
+      if (isMobile) {
+        const portrait = window.innerHeight > window.innerWidth;
+        setIsPortrait(portrait);
+      }
+    };
+
+    checkDevice();
+    checkOrientation();
+
+    window.addEventListener('resize', checkOrientation);
+    window.addEventListener('orientationchange', () => {
+      setTimeout(checkOrientation, 100); // orientationchange後の遅延
+    });
+
+    return () => {
+      window.removeEventListener('resize', checkOrientation);
+      window.removeEventListener('orientationchange', checkOrientation);
+    };
+  }, [isMobile]);
+
+  return { isMobilePortrait: isMobile && isPortrait };
+}

--- a/game-client/types/MatchingTypes.ts
+++ b/game-client/types/MatchingTypes.ts
@@ -1,2 +1,2 @@
 /** マッチングの状態を表す型 */
-export type MatchingStatus = "InProgress" | "Interrupted" | "Completed";
+export type MatchingStatus = "NotStarted" | "InProgress" | "Interrupted" | "Completed";


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記載 -->
スマホで縦向きのままゲーム開始しないようにする

## 関連Issue

- Closes #77 

## 変更内容

* トップページの横画面推奨を解除
* 縦画面のときはマッチング開始しないorマッチングをキャンセル
* 画面の回転状態を取得するhookを作成
* ターン番号が更新されない問題の解消

## 動作確認

### 確認環境

- [x] local
- [ ] dev

### 手順

1. プレイヤーAでマッチングを開始
2. プレイヤーB（スマホ）でマッチングを開始
3. 画面を横にしないとゲームは開始しない

### 結果

- [x] 期待通りに動作する
- [x] 既存機能へ副作用がないことを確認した

## 影響範囲

- [x] game-client
- [ ] game_server
- [ ] local-websocket-apigateway
- [ ] local-dynamodb-initialize
- [ ] local-eventbridge-scheduler
- [ ] ドキュメント

## テスト

- [ ] 追加/変更した処理に対して必要なテストを実施した
- [x] 手動確認のみ（理由を下に記載）

手動確認理由（必要時）: 内容的にテスト作るの難しい・・・

## UI変更（必要時）

- スクリーンショット or 動画を添付

## レビュー観点（任意）

<!-- 特に見てほしい点があれば記載 -->

## チェックリスト

- [x] ブランチ名が規約に沿っている（`feature/*`, `fix/*`, `chore/*`, `docs/*`）
- [x] PRタイトルが規約に沿っている（`<type>: <概要> (#issue番号)`）
- [x] 1PR1目的になっている
- [x] 不要な差分（無関係な整形/リネーム等）がない
- [ ] ~~破壊的変更がある場合、内容と移行手順を記載した~~

## 備考

上記はあくまで推奨ルールです。従わなくても全然いいですが、迷ったら参考にしてください。
