### PR TITLE
fix: トリガーでの防御ができていないことがある問題の修正 (#79)

### DIFF
--- a/game-client/components/panels/TurnStatePanel/MotionLab.tsx
+++ b/game-client/components/panels/TurnStatePanel/MotionLab.tsx
@@ -58,7 +58,7 @@ export default function TurnStateMotionLabPanel(props: MotionLabProps) {
           </div>
           <div className={styles.turnInfo}>
             <p>Turn</p>
-            <p><span className={styles.currentTurn}>{turn}</span> / {maxTurn}</p>
+            <p><span className={styles.currentTurn}>{turn}</span><span className={styles.maxTurn}> / {maxTurn}</span></p>
           </div>
 
         </LonghexOutline>

--- a/game-client/components/panels/TurnStatePanel/index.module.css
+++ b/game-client/components/panels/TurnStatePanel/index.module.css
@@ -41,3 +41,7 @@
   font-weight: bold;
   color: #13a9b7ff;
 }
+
+.maxTurn {
+  color: white;
+}

--- a/game-client/game-logics/phaser/scenes/controllers/TurnReplayController.ts
+++ b/game-client/game-logics/phaser/scenes/controllers/TurnReplayController.ts
@@ -60,7 +60,10 @@ export class TurnReplayController {
     console.log(`=== ステップ ${stepIndex + 1} 実行開始 ===`);
 
     this.replayActions(turn, stepIndex);
-    this.replayCombats(turn, stepIndex);
+    this.deps.scene.time.delayedCall(500, () => {
+      // 少し遅れて防御や攻撃の演出して、移動後のセルで戦闘が起きていることがわかるようにする
+      this.replayCombats(turn, stepIndex);
+    });
 
     // ステップ再生後に視界情報を更新する。
     this.deps.updateFieldViewVisibility();

--- a/game_server/rust_app/src/domain/triggergame_simulator/models/combat/combat.rs
+++ b/game_server/rust_app/src/domain/triggergame_simulator/models/combat/combat.rs
@@ -41,6 +41,18 @@ pub struct Combat {
     is_defeated: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum GuardPattern {
+    /// 両防御
+    Full,
+    /// メイントリガー防御
+    MainOnly,
+    /// サブトリガー防御
+    SubOnly,
+    /// 防御なし
+    None,
+}
+
 impl Combat {
     // privateなコンストラクタ
     fn new(
@@ -177,61 +189,69 @@ impl Combat {
 
         if !is_avoided.value() {
             // ダメージ量の計算
-            if is_defender_facing_attacker_main
-                && defender_main_trigger_status.defense() > 0
-                && is_defender_facing_attacker_sub
-                && defender_sub_trigger_status.defense() > 0
-            {
-                // 両防御の場合
-                let (main_trigger_damage, sub_trigger_damage) = Self::calculate_full_guard_damage(
-                    attacker_base_attack,
-                    defender_base_defense,
-                    TriggerStatus::get_trigger_status(attacker_main_trigger_id.value()).attack()
-                        + TriggerStatus::get_trigger_status(attacker_sub_trigger_id.value())
-                            .attack(),
-                    defender_main_trigger_status.defense(),
-                    defender_sub_trigger_status.defense(),
-                    main_trigger_hp,
-                    sub_trigger_hp,
-                );
+            let guard_pattern = Self::determine_guard_pattern(
+                is_defender_facing_attacker_main,
+                defender_main_trigger_status.defense(),
+                is_defender_facing_attacker_sub,
+                defender_sub_trigger_status.defense(),
+            );
 
-                main_trigger_hp -= main_trigger_damage;
-                sub_trigger_hp -= sub_trigger_damage;
+            match guard_pattern {
+                GuardPattern::Full => {
+                    // 両防御の場合
+                    let (main_trigger_damage, sub_trigger_damage) =
+                        Self::calculate_full_guard_damage(
+                            attacker_base_attack,
+                            defender_base_defense,
+                            TriggerStatus::get_trigger_status(attacker_main_trigger_id.value())
+                                .attack()
+                                + TriggerStatus::get_trigger_status(
+                                    attacker_sub_trigger_id.value(),
+                                )
+                                .attack(),
+                            defender_main_trigger_status.defense(),
+                            defender_sub_trigger_status.defense(),
+                            main_trigger_hp,
+                            sub_trigger_hp,
+                        );
 
-                if main_trigger_hp <= 0 || sub_trigger_hp <= 0 {
+                    main_trigger_hp -= main_trigger_damage;
+                    sub_trigger_hp -= sub_trigger_damage;
+
+                    if main_trigger_hp <= 0 || sub_trigger_hp <= 0 {
+                        is_defeated = true;
+                    }
+                }
+                GuardPattern::MainOnly => {
+                    // 片方防御の場合（メイントリガーのみ防御）
+                    let damage = Self::calculate_partial_guard_damage(
+                        attacker_base_attack,
+                        defender_base_defense,
+                        TriggerStatus::get_trigger_status(attacker_main_trigger_id.value())
+                            .attack()
+                            + TriggerStatus::get_trigger_status(attacker_sub_trigger_id.value())
+                                .attack(),
+                        defender_main_trigger_status.defense(),
+                    );
+                    main_trigger_hp -= damage;
+                }
+                GuardPattern::SubOnly => {
+                    // 片方防御の場合（サブトリガーのみ防御）
+                    let damage = Self::calculate_partial_guard_damage(
+                        attacker_base_attack,
+                        defender_base_defense,
+                        TriggerStatus::get_trigger_status(attacker_main_trigger_id.value())
+                            .attack()
+                            + TriggerStatus::get_trigger_status(attacker_sub_trigger_id.value())
+                                .attack(),
+                        defender_sub_trigger_status.defense(),
+                    );
+                    sub_trigger_hp -= damage;
+                }
+                GuardPattern::None => {
+                    // 両トリガーが防御トリガーでないときは即撃墜
                     is_defeated = true;
                 }
-            } else if is_defender_facing_attacker_main
-                && defender_main_trigger_status.defense() > 0
-                && !is_defender_facing_attacker_sub
-            {
-                // 片方防御の場合（メイントリガーのみ防御）
-                let damage = Self::calculate_partial_guard_damage(
-                    attacker_base_attack,
-                    defender_base_defense,
-                    TriggerStatus::get_trigger_status(attacker_main_trigger_id.value()).attack()
-                        + TriggerStatus::get_trigger_status(attacker_sub_trigger_id.value())
-                            .attack(),
-                    defender_main_trigger_status.defense(),
-                );
-                main_trigger_hp -= damage;
-            } else if !is_defender_facing_attacker_main
-                && is_defender_facing_attacker_sub
-                && defender_sub_trigger_status.defense() > 0
-            {
-                // 片方防御の場合（サブトリガーのみ防御）
-                let damage = Self::calculate_partial_guard_damage(
-                    attacker_base_attack,
-                    defender_base_defense,
-                    TriggerStatus::get_trigger_status(attacker_main_trigger_id.value()).attack()
-                        + TriggerStatus::get_trigger_status(attacker_sub_trigger_id.value())
-                            .attack(),
-                    defender_sub_trigger_status.defense(),
-                );
-                sub_trigger_hp -= damage;
-            } else {
-                // 両トリガーが防御トリガーでないときは即撃墜
-                is_defeated = true;
             }
         }
 
@@ -357,6 +377,38 @@ impl Combat {
         }
     }
 
+    /// ガードパターンの判定
+    /// * 両防御：攻撃者に向いているトリガーが両方とも防御トリガーで、防御力が0より大きい
+    /// * メイントリガー防御：攻撃者に向いているトリガーがメイントリガーで、防御力が0より大きい、かつサブトリガーが攻撃者に向いていないか、防御力が0のとき
+    /// * サブトリガー防御：攻撃者に向いているトリガーがサブトリガーで、防御力が0より大きい、かつメイントリガーが攻撃者に向いていないか、防御力が0のとき
+    /// * 防御なし：攻撃者に向いているトリガーがない、または攻撃者に向いているトリガーの防御力が0のとき
+    pub(super) fn determine_guard_pattern(
+        is_defender_facing_attacker_main: bool,
+        defender_main_trigger_defense: i32,
+        is_defender_facing_attacker_sub: bool,
+        defender_sub_trigger_defense: i32,
+    ) -> GuardPattern {
+        if is_defender_facing_attacker_main
+            && defender_main_trigger_defense > 0
+            && is_defender_facing_attacker_sub
+            && defender_sub_trigger_defense > 0
+        {
+            GuardPattern::Full
+        } else if is_defender_facing_attacker_main
+            && defender_main_trigger_defense > 0
+            && (!is_defender_facing_attacker_sub || defender_sub_trigger_defense == 0)
+        {
+            GuardPattern::MainOnly
+        } else if is_defender_facing_attacker_sub
+            && defender_sub_trigger_defense > 0
+            && (!is_defender_facing_attacker_main || defender_main_trigger_defense == 0)
+        {
+            GuardPattern::SubOnly
+        } else {
+            GuardPattern::None
+        }
+    }
+
     /// 両防御の場合のダメージを計算
     /// 例：9 × 8 × 2 - 4 × (10 + 5) = 144 - 60
     fn calculate_full_guard_damage(
@@ -413,6 +465,18 @@ impl Combat {
     }
 
     // ゲッター
+    pub fn main_trigger_hp(&self) -> i32 {
+        self.main_trigger_hp
+    }
+
+    pub fn sub_trigger_hp(&self) -> i32 {
+        self.sub_trigger_hp
+    }
+
+    pub fn is_avoided(&self) -> bool {
+        self.is_avoided.value()
+    }
+
     pub fn is_defeated(&self) -> bool {
         self.is_defeated
     }

--- a/game_server/rust_app/src/domain/triggergame_simulator/models/combat/combat_test.rs
+++ b/game_server/rust_app/src/domain/triggergame_simulator/models/combat/combat_test.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod tests {
-    use super::super::combat::Combat;
+    use super::super::combat::{Combat, GuardPattern};
     use crate::domain::triggergame_simulator::models::action::trigger_azimuth::trigger_azimuth::TriggerAzimuth;
+    use crate::domain::triggergame_simulator::models::combat;
     use crate::domain::triggergame_simulator::models::game::visibility::Visibility;
     use crate::domain::unit_management::models::unit::position::position::Position;
     use crate::domain::unit_management::models::unit::trigger_id::trigger_id::TriggerId;
@@ -40,7 +41,7 @@ mod tests {
             TriggerId::new("ASTEROID".to_string()),
             TriggerAzimuth::new(180),
             TriggerAzimuth::new(180),
-            10,
+            3,
             create_test_unit_id(),
             Position::new(21, 22),
             TriggerId::new("IBIS".to_string()),
@@ -49,13 +50,86 @@ mod tests {
             100,
             TriggerAzimuth::new(0),
             TriggerAzimuth::new(0),
-            5,
-            2,
+            4,
+            3,
             &mut visibility,
         );
         println!("Combat creation result: {:?}", combat);
 
         // Combatの生成に成功するか
         assert!(combat.is_some());
+    }
+
+    /// シューターが画面右上で前向きにトリガーを向けて攻撃（同じ階層）
+    /// 回避を0にすることで確実にメイントリガーの防御行動が発生することを確認する
+    #[test]
+    fn test_create_combat_shooter_02() {
+        let mut visibility = create_test_visiblity();
+        let combat = Combat::create(
+            create_test_unit_id(),
+            Position::new(6, 35),
+            TriggerId::new("RAYGUST".to_string()),
+            TriggerId::new("ASTEROID".to_string()),
+            TriggerAzimuth::new(354),
+            TriggerAzimuth::new(3),
+            3,
+            create_test_unit_id(),
+            Position::new(29, 4),
+            TriggerId::new("RAYGUST".to_string()),
+            TriggerId::new("ASTEROID".to_string()),
+            100,
+            100,
+            TriggerAzimuth::new(5),
+            TriggerAzimuth::new(352),
+            4,
+            0,
+            &mut visibility,
+        );
+        println!("Combat creation result: {:?}", combat);
+
+        // Combatの生成に成功するか
+        let combat = combat.unwrap();
+        assert!(
+            combat.is_avoided() == false // 回避されていないこと
+                && combat.is_defeated() == false // 撃墜していないこと
+                && combat.main_trigger_hp() < 100 // メイントリガーのHPが減少していること
+        );
+    }
+
+    /// 両防御パターンテスト
+    #[test]
+    fn test_determine_guard_pattern_full() {
+        let pattern = Combat::determine_guard_pattern(true, 10, true, 5);
+        assert_eq!(pattern, GuardPattern::Full);
+    }
+
+    /// メイントリガー防御パターンテスト
+    #[test]
+    fn test_determine_guard_pattern_main_only() {
+        let pattern = Combat::determine_guard_pattern(true, 10, false, 5);
+        assert_eq!(pattern, GuardPattern::MainOnly);
+
+        let pattern_sub_not_defensive = Combat::determine_guard_pattern(true, 10, true, 0);
+        assert_eq!(pattern_sub_not_defensive, GuardPattern::MainOnly);
+    }
+
+    /// サブトリガー防御パターンテスト
+    #[test]
+    fn test_determine_guard_pattern_sub_only() {
+        let pattern = Combat::determine_guard_pattern(false, 10, true, 5);
+        assert_eq!(pattern, GuardPattern::SubOnly);
+
+        let pattern_main_not_defensive = Combat::determine_guard_pattern(true, 0, true, 5);
+        assert_eq!(pattern_main_not_defensive, GuardPattern::SubOnly);
+    }
+
+    /// 防御なしパターンテスト
+    #[test]
+    fn test_determine_guard_pattern_none() {
+        let pattern = Combat::determine_guard_pattern(false, 10, false, 5);
+        assert_eq!(pattern, GuardPattern::None);
+
+        let pattern_non_defensive = Combat::determine_guard_pattern(true, 0, true, 0);
+        assert_eq!(pattern_non_defensive, GuardPattern::None);
     }
 }


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記載 -->
両トリガーが攻撃者に向いているのに、防御可能トリガーが反応しないことがある問題の修正
防御時のパターンに穴があったため発生した。

## 関連Issue

- Closes #79 

## 変更内容

- ダメージ計算のパターンを明示化
- パターンごとのテストコードを実装
- 防御や回避演出は移動後に出るよう修正
- chromeだと右上のターン数が黒で表示されてしまう問題の修正

## 動作確認

### 確認環境

- [x] local
- [ ] dev

### 手順

1. 三雲修だけにしてゲーム開始
2. 対戦相手の三雲修を正面にして進める
3. 防御トリガーが発動することを確認する

### 結果

- [x] 期待通りに動作する
- [x] 既存機能へ副作用がないことを確認した

## 影響範囲

- [x] game-client
- [x] game_server
- [ ] local-websocket-apigateway
- [ ] local-dynamodb-initialize
- [ ] local-eventbridge-scheduler
- [ ] ドキュメント

## テスト

- [x] 追加/変更した処理に対して必要なテストを実施した
- [ ] 手動確認のみ（理由を下に記載）

手動確認理由（必要時）:

## UI変更（必要時）

- スクリーンショット or 動画を添付

## レビュー観点（任意）

<!-- 特に見てほしい点があれば記載 -->

## チェックリスト

- [x] ブランチ名が規約に沿っている（`feature/*`, `fix/*`, `chore/*`, `docs/*`）
- [x] PRタイトルが規約に沿っている（`<type>: <概要> (#issue番号)`）
- [x] 1PR1目的になっている
- [x] 不要な差分（無関係な整形/リネーム等）がない
- [ ] ~~破壊的変更がある場合、内容と移行手順を記載した~~

## 備考

上記はあくまで推奨ルールです。従わなくても全然いいですが、迷ったら参考にしてください。
