### PR TITLE
fix: トリガー角度の向きが90度ずれている問題の修正 (#92)

### DIFF
--- a/game-client/game-logics/hexUtils.ts
+++ b/game-client/game-logics/hexUtils.ts
@@ -107,7 +107,7 @@ export class HexUtils {
 
     const dx = worldMouseX - centerX;
     const dy = worldMouseY - centerY;
-    let angle = (Math.atan2(dy, dx) * 180) / Math.PI;
+    let angle = (Math.atan2(dy, dx) * 180) / Math.PI + 90; // 0度を上方向にするために90度補正
     if (angle < 0) angle += 360;
     return Math.round(angle);
   }


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記載 -->

トリガー角度の向きが-90度になっていた(Phaserのデフォルト挙動)
+90を加えることでドラッグした位置にトリガーの向きが来るようになった

## 関連Issue

- Closes #92 

## 変更内容

- トリガー設定の向きを90度プラス

## 動作確認

### 確認環境

- [x] local
- [ ] dev

### 手順

1. ゲームを開始する
2. 動きの設定でトリガーの向きとドラッグ位置を比較する

### 結果

- [x] 期待通りに動作する
- [x] 既存機能へ副作用がないことを確認した

## 影響範囲

- [x] game-client
- [ ] game_server
- [ ] local-websocket-apigateway
- [ ] local-dynamodb-initialize
- [ ] local-eventbridge-scheduler
- [x] ドキュメント

## テスト

- [x] 追加/変更した処理に対して必要なテストを実施した
- [ ] 手動確認のみ（理由を下に記載）

手動確認理由（必要時）:

## UI変更（必要時）

- スクリーンショット or 動画を添付

## レビュー観点（任意）

<!-- 特に見てほしい点があれば記載 -->

## チェックリスト

- [x] ブランチ名が規約に沿っている（`feature/*`, `fix/*`, `chore/*`, `docs/*`）
- [x] PRタイトルが規約に沿っている（`<type>: <概要> (#issue番号)`）
- [x] 1PR1目的になっている
- [x] 不要な差分（無関係な整形/リネーム等）がない
- [ ] ~~破壊的変更がある場合、内容と移行手順を記載した~~

## 備考

上記はあくまで推奨ルールです。従わなくても全然いいですが、迷ったら参考にしてください。
