### PR TITLE
fix: 攻撃持の行動力消費が反映されてない問題の修正 (#93)

### DIFF
--- a/game-client/hooks/device/useDeviceOrientation.ts
+++ b/game-client/hooks/device/useDeviceOrientation.ts
@@ -36,7 +36,7 @@ export default function useDeviceOrientation({ onOrientationChange }: UseDeviceO
 
     window.addEventListener('resize', checkOrientation);
     window.addEventListener('orientationchange', () => {
-      setTimeout(checkOrientation, 100); // orientationchange後の遅延
+      checkOrientation();
     });
 
     return () => {

--- a/game_server/rust_app/src/domain/triggergame_simulator/configs/game_config.rs
+++ b/game_server/rust_app/src/domain/triggergame_simulator/configs/game_config.rs
@@ -38,7 +38,7 @@ impl GameConfig {
             gameboard_width: 36,
             gameboard_height: 36,
             avoid_weight: 100,
-            damage_weight: 1.0,
+            damage_weight: 2.5,
             defend_weight: 1.0,
             min_damage: 20,
             motion_lab_seconds: 80, // 動きの設定時間を80秒に

--- a/game_server/rust_app/src/domain/triggergame_simulator/models/action/action.rs
+++ b/game_server/rust_app/src/domain/triggergame_simulator/models/action/action.rs
@@ -224,6 +224,10 @@ impl Action {
         self.current_action_points = current_action_points;
     }
 
+    pub fn set_position(&mut self, position: Position) {
+        self.position = position;
+    }
+
     // ゲッター
     pub fn action_id(&self) -> &ActionId {
         &self.action_id

--- a/game_server/rust_app/src/domain/triggergame_simulator/models/combat/combat.rs
+++ b/game_server/rust_app/src/domain/triggergame_simulator/models/combat/combat.rs
@@ -205,10 +205,9 @@ impl Combat {
             defender_sub_trigger_status.angle(),
         );
 
-        let mut is_defeated = false;
         if !is_defender_facing_attacker_main && !is_defender_facing_attacker_sub {
             // トリガーが向いていない場合は即撃墜
-            is_defeated = true;
+            defender_unit.bailout();
         }
 
         // 回避計算の実行
@@ -275,12 +274,6 @@ impl Combat {
                         defender_sub_trigger_status.defense(),
                         defender_unit,
                     );
-
-                    if defender_unit.main_trigger_hp().is_depleted()
-                        || defender_unit.sub_trigger_hp().is_depleted()
-                    {
-                        is_defeated = true;
-                    }
                 }
                 GuardPattern::MainOnly => {
                     // 行動力があればメイントリガーのシールドを貼り直し(トリガーHPを全回復)
@@ -320,7 +313,7 @@ impl Combat {
                 }
                 GuardPattern::None => {
                     // 両トリガーが防御トリガーでないときは即撃墜
-                    is_defeated = true;
+                    defender_unit.bailout();
                 }
             }
         }
@@ -345,7 +338,7 @@ impl Combat {
             defender_unit.main_trigger_hp().clone(),
             defender_unit.sub_trigger_hp().clone(),
             is_avoided,
-            is_defeated,
+            defender_unit.is_bailed_out(),
         ))
     }
 

--- a/game_server/rust_app/src/domain/triggergame_simulator/models/combat/combat.rs
+++ b/game_server/rust_app/src/domain/triggergame_simulator/models/combat/combat.rs
@@ -45,6 +45,18 @@ pub struct Combat {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum AttackPattern {
+    /// 両攻撃
+    Full,
+    /// メイントリガー攻撃
+    MainOnly,
+    /// サブトリガー攻撃
+    SubOnly,
+    /// 攻撃なし
+    None,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum GuardPattern {
     /// 両防御
     Full,
@@ -114,39 +126,63 @@ impl Combat {
         visibility: &mut Visibility,
     ) -> Option<Self> {
         // 攻撃側のメイントリガーが防御側に当たる可能性があるか確認
-        let is_main_trigger_hit = Self::check_trigger_in_range_and_angle(
+        let in_main_trigger_area = Self::check_trigger_in_range_and_angle(
             &attacker_unit.position(),
             &attacker_unit.using_main_trigger_id(),
             &attacker_unit.main_trigger_azimuth(),
             &defender_unit.position(),
         );
         // 攻撃側のサブトリガーが防御側に当たる可能性があるか確認
-        let is_sub_trigger_hit = Self::check_trigger_in_range_and_angle(
+        let in_sub_trigger_area = Self::check_trigger_in_range_and_angle(
             &attacker_unit.position(),
             &attacker_unit.using_sub_trigger_id(),
             &attacker_unit.sub_trigger_azimuth(),
             &defender_unit.position(),
         );
+
+        // 攻撃者側のメイントリガーの必要行動力
+        let attacker_main_trigger_action_point =
+            TriggerStatus::get_trigger_status(attacker_unit.using_main_trigger_id().value())
+                .action_points();
+        // 攻撃者側のサブトリガーの必要行動力
+        let attacker_sub_trigger_action_point =
+            TriggerStatus::get_trigger_status(attacker_unit.using_sub_trigger_id().value())
+                .action_points();
+
+        // 攻撃パターンの判定
+        let attack_pattern = Self::determine_attack_pattern(
+            in_main_trigger_area,
+            TriggerStatus::get_trigger_status(attacker_unit.using_main_trigger_id().value())
+                .attack(),
+            in_sub_trigger_area,
+            TriggerStatus::get_trigger_status(attacker_unit.using_sub_trigger_id().value())
+                .attack(),
+            attacker_unit.current_action_points().value(),
+            attacker_main_trigger_action_point,
+            attacker_sub_trigger_action_point,
+        );
+
         // 攻撃側側から見て防御側が見えているか確認
         let is_defender_visible = visibility
             .check_combat_visibility(&attacker_unit.position(), &defender_unit.position());
-        if (!is_main_trigger_hit && !is_sub_trigger_hit) || !is_defender_visible {
-            // 射程外 かつ 角度の範囲外　または 視界外の場合はNoneを返す
+        if attack_pattern == AttackPattern::None || !is_defender_visible {
+            // 攻撃できない　または 視界外の場合はNoneを返す
             return None;
         }
 
-        // 以降の処理に進む場合、攻撃は実行されたものとするため、攻撃側の行動力を消費する
-        if is_main_trigger_hit {
-            let _ = attacker_unit.consume_action_points(
-                TriggerStatus::get_trigger_status(attacker_unit.using_main_trigger_id().value())
-                    .action_points(),
-            );
-        }
-        if is_sub_trigger_hit {
-            let _ = attacker_unit.consume_action_points(
-                TriggerStatus::get_trigger_status(attacker_unit.using_sub_trigger_id().value())
-                    .action_points(),
-            );
+        match attack_pattern {
+            AttackPattern::Full => {
+                let _ = attacker_unit.consume_action_points(
+                    attacker_main_trigger_action_point + attacker_sub_trigger_action_point,
+                );
+            }
+            AttackPattern::MainOnly => {
+                let _ = attacker_unit.consume_action_points(attacker_main_trigger_action_point);
+            }
+            AttackPattern::SubOnly => {
+                let _ = attacker_unit.consume_action_points(attacker_sub_trigger_action_point);
+            }
+            AttackPattern::None => {}
         }
 
         let defender_main_trigger_status =
@@ -188,7 +224,25 @@ impl Combat {
         let is_avoided = Self::calculate_avoidance(defender_base_avoid, trigger_avoid);
 
         if !is_avoided.value() {
-            // ダメージ量の計算
+            // まず攻撃パターンに基づき、実際に発動した攻撃の攻撃値をトリガー毎に計算する
+            let attacker_main_attack = match attack_pattern {
+                AttackPattern::Full | AttackPattern::MainOnly => {
+                    TriggerStatus::get_trigger_status(attacker_unit.using_main_trigger_id().value())
+                        .attack()
+                }
+                _ => 0,
+            };
+            let attacker_sub_attack = match attack_pattern {
+                AttackPattern::Full | AttackPattern::SubOnly => {
+                    TriggerStatus::get_trigger_status(attacker_unit.using_sub_trigger_id().value())
+                        .attack()
+                }
+                _ => 0,
+            };
+            // 攻撃値の合計
+            let total_trigger_attack = attacker_main_attack + attacker_sub_attack;
+
+            // 防御側のトリガーの向きと防御力からガードパターンを判定する
             let guard_pattern = Self::determine_guard_pattern(
                 is_defender_facing_attacker_main,
                 defender_main_trigger_status.defense(),
@@ -196,6 +250,7 @@ impl Combat {
                 defender_sub_trigger_status.defense(),
             );
 
+            // ガードパターンに基づきダメージ計算を行い、防御側のHPを減少させる
             match guard_pattern {
                 GuardPattern::Full => {
                     // 行動力があれば２つのシールドを貼り直し(トリガーHPを全回復)
@@ -215,14 +270,7 @@ impl Combat {
                     Self::calculate_full_guard_damage(
                         attacker_base_attack,
                         defender_base_defense,
-                        TriggerStatus::get_trigger_status(
-                            attacker_unit.using_main_trigger_id().value(),
-                        )
-                        .attack()
-                            + TriggerStatus::get_trigger_status(
-                                attacker_unit.using_sub_trigger_id().value(),
-                            )
-                            .attack(),
+                        total_trigger_attack,
                         defender_main_trigger_status.defense(),
                         defender_sub_trigger_status.defense(),
                         defender_unit,
@@ -247,14 +295,7 @@ impl Combat {
                     let damage = Self::calculate_partial_guard_damage(
                         attacker_base_attack,
                         defender_base_defense,
-                        TriggerStatus::get_trigger_status(
-                            attacker_unit.using_main_trigger_id().value(),
-                        )
-                        .attack()
-                            + TriggerStatus::get_trigger_status(
-                                attacker_unit.using_sub_trigger_id().value(),
-                            )
-                            .attack(),
+                        total_trigger_attack,
                         defender_main_trigger_status.defense(),
                     );
                     defender_unit.decrease_main_trigger_hp(damage);
@@ -272,14 +313,7 @@ impl Combat {
                     let damage = Self::calculate_partial_guard_damage(
                         attacker_base_attack,
                         defender_base_defense,
-                        TriggerStatus::get_trigger_status(
-                            attacker_unit.using_main_trigger_id().value(),
-                        )
-                        .attack()
-                            + TriggerStatus::get_trigger_status(
-                                attacker_unit.using_sub_trigger_id().value(),
-                            )
-                            .attack(),
+                        total_trigger_attack,
                         defender_sub_trigger_status.defense(),
                     );
                     defender_unit.decrease_sub_trigger_hp(damage);
@@ -413,6 +447,85 @@ impl Combat {
         }
     }
 
+    /// 攻撃パターンの判定
+    /// * 両攻撃：
+    ///     * 攻撃者の両トリガーの範囲内に防御者がいる
+    ///     * 両トリガーの攻撃力が0より大きい
+    ///     * 両トリガーの必要行動力を足し合わせた値が、攻撃者の現在の行動力以下である
+    /// * メイントリガー攻撃：
+    ///     * 攻撃者のメイントリガーの範囲内に防御者がいる
+    ///     * メイントリガーの攻撃力が0より大きい
+    ///     * メイントリガーの必要行動力が、攻撃者の現在の行動力以下である
+    ///     * 以下のいずれかの条件を満たす：
+    ///         * サブトリガーの範囲内に防御者がいない、またはサブトリガーの攻撃力が0である、またはサブトリガーの必要行動力が攻撃者の現在の行動力を超えている（サブで攻撃不可能）
+    ///         * サブトリガー単体は発動可能だが、メインとサブの必要行動力を足し合わせた値が攻撃者の現在の行動力を超えている（両方は撃てないためメインを優先）
+    /// * サブトリガー攻撃：
+    ///     * 攻撃者のサブトリガーの範囲内に防御者がいる
+    ///     * サブトリガーの攻撃力が0より大きい
+    ///     * サブトリガーの必要行動力が、攻撃者の現在の行動力以下である
+    ///     * メイントリガーの範囲内に防御者がいない、またはメイントリガーの攻撃力が0である、またはメイントリガーの必要行動力が、攻撃者の現在の行動力を超えている
+    ///      （メインが攻撃不可能な場合のみ、サブ単独攻撃が発生する）
+    /// * 攻撃なし：
+    ///     * 攻撃者の両トリガーの範囲内に防御者がいない、または両トリガーの攻撃力が0である、または攻撃者の現在の行動力が、有効なトリガーの最低必要行動力を下回っている
+    ///
+    /// # Arguments
+    /// * `in_main_trigger_area` - 攻撃者のメイントリガーの範囲内にが防御者がいるか
+    /// * `attacker_main_trigger_attack` - 攻撃者のメイントリガーの攻撃力
+    /// * `in_sub_trigger_area` - 攻撃者のサブトリガーの範囲内に防御者がいるか
+    /// * `attacker_sub_trigger_attack` - 攻撃者のサブトリガーの攻撃力
+    /// * `attacker_current_action_points` - 攻撃者の現在の行動力
+    /// * `attacker_main_trigger_action_points` - 攻撃者のメイントリガーの必要行動力
+    /// * `attacker_sub_trigger_action_points` - 攻撃者のサブトリガーの必要行動力
+    pub(super) fn determine_attack_pattern(
+        in_main_trigger_area: bool,
+        attacker_main_trigger_attack: i32,
+        in_sub_trigger_area: bool,
+        attacker_sub_trigger_attack: i32,
+        attacker_current_action_points: i32,
+        attacker_main_trigger_action_points: i32,
+        attacker_sub_trigger_action_points: i32,
+    ) -> AttackPattern {
+        // 両攻撃: 両方のトリガーが有効かつ合計行動力以内
+        if in_main_trigger_area
+            && attacker_main_trigger_attack > 0
+            && in_sub_trigger_area
+            && attacker_sub_trigger_attack > 0
+            && attacker_current_action_points
+                >= (attacker_main_trigger_action_points + attacker_sub_trigger_action_points)
+        {
+            AttackPattern::Full
+        // メイントリガー攻撃:
+        // メインが発動可能で、かつ以下のいずれかを満たす場合
+        // - サブが範囲外、またはサブの攻撃力が0、またはサブが行動不能
+        // - サブ単体は発動可能だが、メイン+サブの合計が現在の行動力を超える（両方撃てないためメインを優先）
+        } else if in_main_trigger_area
+            && attacker_main_trigger_attack > 0
+            && attacker_current_action_points >= attacker_main_trigger_action_points
+            && (!in_sub_trigger_area
+                || attacker_sub_trigger_attack == 0
+                || attacker_current_action_points < attacker_sub_trigger_action_points
+                || (in_sub_trigger_area
+                    && attacker_sub_trigger_attack > 0
+                    && attacker_current_action_points >= attacker_sub_trigger_action_points
+                    && attacker_current_action_points
+                        < (attacker_main_trigger_action_points
+                            + attacker_sub_trigger_action_points)))
+        {
+            AttackPattern::MainOnly
+        // サブトリガー攻撃: サブが発動可能で、かつメインが発動不能な場合のみ
+        } else if in_sub_trigger_area
+            && attacker_sub_trigger_attack > 0
+            && attacker_current_action_points >= attacker_sub_trigger_action_points
+            && (!in_main_trigger_area
+                || attacker_main_trigger_attack == 0
+                || attacker_current_action_points < attacker_main_trigger_action_points)
+        {
+            AttackPattern::SubOnly
+        } else {
+            AttackPattern::None
+        }
+    }
+
     /// ガードパターンの判定
     /// * 両防御：攻撃者に向いているトリガーが両方とも防御トリガーで、防御力が0より大きい
     /// * メイントリガー防御：攻撃者に向いているトリガーがメイントリガーで、防御力が0より大きい、かつサブトリガーが攻撃者に向いていないか、防御力が0のとき
@@ -474,11 +587,6 @@ impl Combat {
             damage * (defender_unit.main_trigger_hp().value() as f64) / total_hp;
         let sub_trigger_damage =
             damage * (defender_unit.sub_trigger_hp().value() as f64) / total_hp;
-
-        // (
-        //     main_trigger_damage.floor() as i32,
-        //     sub_trigger_damage.floor() as i32,
-        // )
 
         defender_unit.decrease_main_trigger_hp(main_trigger_damage.floor() as i32);
         defender_unit.decrease_sub_trigger_hp(sub_trigger_damage.floor() as i32);

--- a/game_server/rust_app/src/domain/triggergame_simulator/models/combat/combat_test.rs
+++ b/game_server/rust_app/src/domain/triggergame_simulator/models/combat/combat_test.rs
@@ -201,6 +201,122 @@ use crate::domain::unit_management::models::unit::wait_time::wait_time::WaitTime
         assert!(combat.is_some());
     }
 
+    /// 行動力がない状態かつHPギリギリの状態から攻撃されて撃墜されるテスト
+    #[test]
+    fn test_bailout_no_action_points() {
+        let mut visibility = create_test_visiblity();
+        let mut attacker_unit = Unit::create(
+            UnitTypeId::new("AMATORI_CHIKA".to_string()),
+            GameId::new(Uuid::new_v4().to_string()),
+            PlayerId::new(Uuid::new_v4().to_string()),
+            Position::new(6, 35),
+            TriggerId::new("IBIS".to_string()),
+            TriggerId::new("BAGWORM".to_string()),
+            HavingTriggerIds::new(vec![TriggerId::new("IBIS".to_string())]),
+            HavingTriggerIds::new(vec![TriggerId::new("BAGWORM".to_string())]),
+            100,
+            100,
+            8,
+            3,
+        );
+        attacker_unit.set_main_trigger_azimuth(TriggerAzimuth::new(354));
+        attacker_unit.set_sub_trigger_azimuth(TriggerAzimuth::new(3));
+
+        let mut defender_unit = Unit::create(
+            UnitTypeId::new("KUGA_YUMA".to_string()),
+            GameId::new(Uuid::new_v4().to_string()),
+            PlayerId::new(Uuid::new_v4().to_string()),
+            Position::new(29, 4),
+            TriggerId::new("SCORPION".to_string()),
+            TriggerId::new("SHIELD".to_string()),
+            HavingTriggerIds::new(vec![TriggerId::new("SCORPION".to_string())]),
+            HavingTriggerIds::new(vec![TriggerId::new("SHIELD".to_string())]),
+            100,
+            15,
+            8,
+            0,
+        );
+        defender_unit.set_main_trigger_azimuth(TriggerAzimuth::new(5));
+        defender_unit.set_sub_trigger_azimuth(TriggerAzimuth::new(352));
+
+        let combat = Combat::create(
+            &mut attacker_unit,
+            2,
+            &mut defender_unit,
+            8,
+            0,
+            &mut visibility,
+        );
+        println!("Combat creation result: {:?}", combat);
+
+        // Combatの生成に成功するか
+        let combat = combat.unwrap();
+        assert!(
+            combat.is_avoided() == false // 回避されていないこと
+                && combat.is_defeated() == true // 撃墜されていること
+        );
+    }
+
+    /// アイビスは片手防御では受けきれないので即撃墜テスト
+    /// 攻撃者の攻撃力：5
+    /// 防御者の防御力：5
+    /// アイビスの攻撃力：10
+    /// シールドの防御力：5
+    #[test]
+    fn test_ibis_bailout() {
+        let mut visibility = create_test_visiblity();
+        let mut attacker_unit = Unit::create(
+            UnitTypeId::new("AVERAGE_MEMBER".to_string()),
+            GameId::new(Uuid::new_v4().to_string()),
+            PlayerId::new(Uuid::new_v4().to_string()),
+            Position::new(6, 35),
+            TriggerId::new("IBIS".to_string()),
+            TriggerId::new("BAGWORM".to_string()),
+            HavingTriggerIds::new(vec![TriggerId::new("IBIS".to_string())]),
+            HavingTriggerIds::new(vec![TriggerId::new("BAGWORM".to_string())]),
+            100,
+            100,
+            8,
+            3,
+        );
+        attacker_unit.set_main_trigger_azimuth(TriggerAzimuth::new(354));
+        attacker_unit.set_sub_trigger_azimuth(TriggerAzimuth::new(3));
+
+        let mut defender_unit = Unit::create(
+            UnitTypeId::new("AVERAGE_MEMBER".to_string()),
+            GameId::new(Uuid::new_v4().to_string()),
+            PlayerId::new(Uuid::new_v4().to_string()),
+            Position::new(29, 4),
+            TriggerId::new("SCORPION".to_string()),
+            TriggerId::new("SHIELD".to_string()),
+            HavingTriggerIds::new(vec![TriggerId::new("SCORPION".to_string())]),
+            HavingTriggerIds::new(vec![TriggerId::new("SHIELD".to_string())]),
+            100,
+            100,
+            8,
+            5,
+        );
+        defender_unit.set_main_trigger_azimuth(TriggerAzimuth::new(5));
+        defender_unit.set_sub_trigger_azimuth(TriggerAzimuth::new(352));
+
+        let combat = Combat::create(
+            &mut attacker_unit,
+            5,
+            &mut defender_unit,
+            5,
+            0,
+            &mut visibility,
+        );
+        println!("Combat creation result: {:?}", combat);
+
+        // Combatの生成に成功するか
+        let combat = combat.unwrap();
+        assert!(
+            combat.is_avoided() == false // 回避されていないこと
+                && combat.is_defeated() == true // 撃墜されていること
+        );
+    }
+
     /// 両攻撃パターンテスト
     #[test]
     fn test_determine_attack_pattern_full() {

--- a/game_server/rust_app/src/domain/triggergame_simulator/models/combat/combat_test.rs
+++ b/game_server/rust_app/src/domain/triggergame_simulator/models/combat/combat_test.rs
@@ -4,7 +4,8 @@ mod tests {
     use crate::domain::player_management::models::player::player_id::player_id::PlayerId;
 use crate::domain::triggergame_simulator::models::action::trigger_azimuth::trigger_azimuth::TriggerAzimuth;
     use crate::domain::triggergame_simulator::models::combat;
-    use crate::domain::triggergame_simulator::models::game::game_id::game_id::GameId;
+    use crate::domain::triggergame_simulator::models::combat::combat::AttackPattern;
+use crate::domain::triggergame_simulator::models::game::game_id::game_id::GameId;
 use crate::domain::triggergame_simulator::models::game::visibility::Visibility;
     use crate::domain::unit_management::models::unit::Unit;
 use crate::domain::unit_management::models::unit::current_action_points::current_action_points::CurrentActionPoints;
@@ -198,6 +199,83 @@ use crate::domain::unit_management::models::unit::wait_time::wait_time::WaitTime
 
         // Combatの生成に成功するか
         assert!(combat.is_some());
+    }
+
+    /// 両攻撃パターンテスト
+    #[test]
+    fn test_determine_attack_pattern_full() {
+        let pattern = Combat::determine_attack_pattern(true, 10, true, 5, 2, 1, 1);
+        assert_eq!(pattern, AttackPattern::Full);
+    }
+
+    /// メイントリガー攻撃パターンテスト - サブトリガーの範囲内に攻撃者がいない
+    #[test]
+    fn test_determine_attack_pattern_main_only() {
+        let pattern = Combat::determine_attack_pattern(true, 10, false, 5, 1, 1, 1);
+        assert_eq!(pattern, AttackPattern::MainOnly);
+    }
+
+    /// メイントリガー攻撃パターンテスト - サブトリガーの攻撃力が0である
+    #[test]
+    fn test_determine_attack_pattern_main_only_sub_attack_zero() {
+        let pattern = Combat::determine_attack_pattern(true, 10, true, 0, 1, 1, 1);
+        assert_eq!(pattern, AttackPattern::MainOnly);
+    }
+
+    /// メイントリガー攻撃パターンテスト - サブトリガーの必要行動力が攻撃者の現在の行動力を超えている
+    #[test]
+    fn test_determine_attack_pattern_main_only_sub_action_points_exceed() {
+        let pattern = Combat::determine_attack_pattern(true, 10, true, 5, 1, 1, 2);
+        assert_eq!(pattern, AttackPattern::MainOnly);
+    }
+
+    /// メイントリガー攻撃パターンテスト - サブトリガー単体は発動可能だが、メインとサブの必要行動力を足し合わせた値が攻撃者の現在の行動力を超えている（両方は撃てないためメインを優先）
+    #[test]
+    fn test_determine_attack_pattern_main_only_main_and_sub_action_points_exceed() {
+        let pattern = Combat::determine_attack_pattern(true, 10, true, 5, 1, 1, 1);
+        assert_eq!(pattern, AttackPattern::MainOnly);
+    }
+
+    /// サブトリガー攻撃パターンテスト - メイントリガーの範囲内に防御者がいない
+    #[test]
+    fn test_determine_attack_pattern_sub_only_main_out_of_range() {
+        let pattern = Combat::determine_attack_pattern(false, 10, true, 5, 2, 1, 1);
+        assert_eq!(pattern, AttackPattern::SubOnly);
+    }
+
+    /// サブトリガー攻撃パターンテスト - メイントリガーの攻撃力が0である
+    #[test]
+    fn test_determine_attack_pattern_sub_only_main_attack_zero() {
+        let pattern = Combat::determine_attack_pattern(true, 0, true, 5, 2, 1, 1);
+        assert_eq!(pattern, AttackPattern::SubOnly);
+    }
+
+    /// サブトリガー攻撃パターンテスト - メイントリガーの必要行動力が、攻撃者の現在の行動力を超えている
+    #[test]
+    fn test_determine_attack_pattern_sub_only_main_action_points_exceed() {
+        let pattern = Combat::determine_attack_pattern(true, 10, true, 5, 1, 2, 1);
+        assert_eq!(pattern, AttackPattern::SubOnly);
+    }
+
+    /// 攻撃なしパターンテスト - 攻撃者の両トリガーの範囲内に防御者がいない
+    #[test]
+    fn test_determine_attack_pattern_none_out_of_range() {
+        let pattern = Combat::determine_attack_pattern(false, 10, false, 5, 5, 2, 1);
+        assert_eq!(pattern, AttackPattern::None);
+    }
+
+    /// 攻撃なしパターンテスト - 攻撃者の両トリガーの攻撃力が0である
+    #[test]
+    fn test_determine_attack_pattern_none_attack_zero() {
+        let pattern = Combat::determine_attack_pattern(true, 0, true, 0, 5, 2, 1);
+        assert_eq!(pattern, AttackPattern::None);
+    }
+
+    /// 攻撃なしパターンテスト - 攻撃者の現在の行動力が、有効なトリガーの最低必要行動力を下回っている
+    #[test]
+    fn test_determine_attack_pattern_none_action_points_insufficient() {
+        let pattern = Combat::determine_attack_pattern(true, 10, true, 5, 1, 2, 2);
+        assert_eq!(pattern, AttackPattern::None);
     }
 
     /// 両防御パターンテスト

--- a/game_server/rust_app/src/domain/triggergame_simulator/services/step_execution_service.rs
+++ b/game_server/rust_app/src/domain/triggergame_simulator/services/step_execution_service.rs
@@ -101,13 +101,11 @@ impl StepExecutionService {
         // - src/domain/triggergame_simulator/models/step/step.rs
         // - Step::step_start の「2. アクションに従ってユニットの移動と使用トリガーの設定」
 
-        const ACTION_POINT_CAN_UPDATE_TRIGGER: i32 = 1;
-
         // 各アクションごとに:
         // - 離脱済みユニットはスキップ
         // - ユニットを移動
         // - 行動ポイント条件を満たす場合にトリガーID/方位角を更新
-        for action in step.actions() {
+        for action in step.actions_mut() {
             let Some(unit) = units.iter_mut().find(|u| u.unit_id() == action.unit_id()) else {
                 return Err(format!(
                     "ユニットID {:?} がアクション {:?} に見つかりません",
@@ -123,7 +121,7 @@ impl StepExecutionService {
                 continue;
             }
 
-            unit.move_to(action.position().clone(), visibility);
+            unit.move_to(action, visibility);
 
             let _ = unit.set_using_triggers(
                 &action.using_main_trigger_id(),
@@ -189,8 +187,6 @@ impl StepExecutionService {
 
         const ACTION_POINT_CAN_ATTACK: i32 = 1;
 
-        // 攻撃側の検索を安定させるため、探索用にユニットをクローンする。
-        let mut attack_units = units.clone();
         let mut generated_combats = Vec::new();
 
         // 各攻撃側アクションごとに:
@@ -198,46 +194,59 @@ impl StepExecutionService {
         // - 敵ユニットを走査
         // - combatを生成してpush
         for action in step.actions() {
-            let Some(attack_unit) = attack_units
-                .iter_mut()
-                .find(|u| u.unit_id() == action.unit_id())
-            else {
-                return Err(format!(
+            // `units` 内のインデックスを見つける。クローンせずに直接 `units` を操作する。
+            let attack_idx = units
+                .iter()
+                .position(|u| u.unit_id() == action.unit_id())
+                .ok_or(format!(
                     "ユニットID {:?} がアクション {:?} に見つかりません",
                     action.unit_id(),
                     action.action_id()
-                ));
-            };
+                ))?;
 
-            // 目的: 攻撃可能条件(行動ポイント)を満たすか判定する。
-            if attack_unit.current_action_points().value() < ACTION_POINT_CAN_ATTACK {
-                // この分岐に入る条件: 行動ポイント不足で攻撃不可な場合。
+            // 行動ポイントや離脱状態のチェックは一時的に共有参照で行う。
+            if units[attack_idx].current_action_points().value() < ACTION_POINT_CAN_ATTACK {
+                // 行動ポイント不足で攻撃不可な場合。
+                // 各トリガーでの攻撃可能な行動力が残っているかは、combat生成時に個別に判定されるため、ここではスキップする。
                 continue;
             }
-            // 目的: 離脱済みユニットの攻撃処理を除外する。
-            if attack_unit.is_bailed_out() {
-                // この分岐に入る条件: 攻撃側ユニットが離脱済みの場合。
-                println!("ユニットID {:?} の攻撃をスキップ", attack_unit.unit_id());
+            if units[attack_idx].is_bailed_out() {
+                println!(
+                    "ユニットID {:?} の攻撃をスキップ",
+                    units[attack_idx].unit_id()
+                );
                 continue;
             }
 
-            for defence_unit in units.iter_mut() {
-                // 目的: 同一プレイヤー間の戦闘判定を除外する。
-                if attack_unit.owner_player_id() == defence_unit.owner_player_id() {
-                    // この分岐に入る条件: 攻撃側と防御側が同一プレイヤー所属の場合。
+            // 防御側は全ユニットを走査する（同一プレイヤーや離脱済みを除外）。
+            for defence_idx in 0..units.len() {
+                if attack_idx == defence_idx {
                     continue;
                 }
-                // 目的: 離脱済みの防御側ユニットは戦闘対象外にする。
+
+                // `split_at_mut` によって同じベクタから同時に2つの可変参照を作る。
+                // (指定したインデックスを境界にして「左側」と「右側」の2つの可変スライスに分割する関数)
+                let (attack_unit, defence_unit) = if attack_idx < defence_idx {
+                    let (left, right) = units.split_at_mut(defence_idx);
+                    (&mut left[attack_idx], &mut right[0])
+                } else {
+                    let (left, right) = units.split_at_mut(attack_idx);
+                    (&mut right[0], &mut left[defence_idx])
+                };
+
+                // 同一プレイヤー間の戦闘判定を除外する。
+                if attack_unit.owner_player_id() == defence_unit.owner_player_id() {
+                    continue;
+                }
+                // 離脱済みの防御側ユニットは戦闘対象外にする。
                 if defence_unit.is_bailed_out() {
-                    // この分岐に入る条件: 防御側ユニットが離脱済みの場合。
                     println!("ユニットID {:?} の戦闘をスキップ", defence_unit.unit_id());
                     continue;
                 }
 
-                // 目的: 射程・視界などの条件を満たす場合のみcombatを生成する。
+                // 射程・視界などの条件を満たす場合のみcombatを生成する。
                 if let Some(combat) = action.generate_combats(attack_unit, defence_unit, visibility)
                 {
-                    // この分岐に入る条件: combat生成条件を満たし、Some(combat)が返る場合。
                     generated_combats.push(combat);
                 }
             }

--- a/game_server/rust_app/src/domain/unit_management/models/unit/unit.rs
+++ b/game_server/rust_app/src/domain/unit_management/models/unit/unit.rs
@@ -1,5 +1,6 @@
 use crate::domain::player_management::models::player::player_id::player_id::PlayerId;
 use crate::domain::triggergame_simulator::models::action::trigger_azimuth::trigger_azimuth::TriggerAzimuth;
+use crate::domain::triggergame_simulator::models::action::Action;
 use crate::domain::triggergame_simulator::models::game::game_id::game_id::GameId;
 use crate::domain::triggergame_simulator::models::game::visibility::{self, Visibility};
 use crate::domain::unit_management::models::unit::trigger_hp::TriggerHP;
@@ -182,25 +183,25 @@ impl Unit {
     /// ベイルアウト済みのユニットは移動できない  
     ///
     /// 行動ポイントが不足している場合は移動できない  
-    pub fn move_to(&mut self, new_position: Position, visibility: &mut Visibility) -> bool {
+    pub fn move_to(&mut self, action: &mut Action, visibility: &mut Visibility) -> bool {
         if self.is_bailout.is_bailout() {
             return false;
         }
         // 現在位置と同じなら移動しない
-        if self.position == new_position {
+        if self.position == *action.position() {
             return false;
         }
         // 移動に必要な行動ポイントを取得
         let required_action_points =
-            visibility.get_action_points_for_move(&self.position, &new_position);
+            visibility.get_action_points_for_move(&self.position, action.position());
 
         if self.current_action_points.value() < required_action_points {
             // 行動ポイントが不足している場合は移動できない
+            action.set_position(self.position.clone()); // 移動できないので位置を元に戻す
             return false;
         }
-        self.position = new_position;
-        self.current_action_points =
-            CurrentActionPoints::new(self.current_action_points.value() - required_action_points);
+        self.position = action.position().clone();
+        let _ = self.consume_action_points(required_action_points);
         true
     }
 

--- a/game_server/rust_app/src/domain/unit_management/models/unit/unit.rs
+++ b/game_server/rust_app/src/domain/unit_management/models/unit/unit.rs
@@ -285,11 +285,21 @@ impl Unit {
     /// メイントリガーHPを減少
     pub fn decrease_main_trigger_hp(&mut self, amount: i32) {
         self.main_trigger_hp.decrease(amount);
+
+        if self.main_trigger_hp.value() <= 0 {
+            // メイントリガーが破壊された場合、ユニットはベイルアウトする
+            self.bailout();
+        }
     }
 
     /// サブトリガーHPを減少
     pub fn decrease_sub_trigger_hp(&mut self, amount: i32) {
         self.sub_trigger_hp.decrease(amount);
+
+        if self.sub_trigger_hp.value() <= 0 {
+            // サブトリガーが破壊された場合、ユニットはベイルアウトする
+            self.bailout();
+        }
     }
 
     /// ベイルアウト

--- a/game_server/rust_app/src/domain/unit_management/models/unit/unit_test.rs
+++ b/game_server/rust_app/src/domain/unit_management/models/unit/unit_test.rs
@@ -1,6 +1,11 @@
 #[cfg(test)]
 mod tests {
     use crate::domain::player_management::models::player::player_id::player_id::PlayerId;
+    use crate::domain::triggergame_simulator::models::action::action_type::action_type::{
+        ActionType, ActionTypeValue,
+    };
+    use crate::domain::triggergame_simulator::models::action::trigger_azimuth::trigger_azimuth::TriggerAzimuth;
+    use crate::domain::triggergame_simulator::models::action::Action;
     use crate::domain::triggergame_simulator::models::game::game_id::game_id::GameId;
     use crate::domain::triggergame_simulator::models::game::visibility::{self, Visibility};
     use crate::domain::unit_management::models::unit::trigger_hp::TriggerHP;
@@ -35,11 +40,21 @@ mod tests {
 
     #[test]
     fn test_move_to() {
+        let mut action = Action::create(
+            ActionType::new(ActionTypeValue::Move),
+            UnitId::new(Uuid::new_v4().to_string()),
+            UnitTypeId::new(Uuid::new_v4().to_string()),
+            Position::new(5, 5),
+            TriggerId::new("IBIS".to_string()),
+            TriggerId::new("SHIELD".to_string()),
+            TriggerAzimuth::new(0),
+            TriggerAzimuth::new(0),
+            CurrentActionPoints::new(5),
+        );
         let mut unit = create_test_unit();
-        let new_position = Position::new(5, 5);
         let mut visibility = Visibility::create();
 
-        unit.move_to(new_position.clone(), &mut visibility);
+        unit.move_to(&mut action, &mut visibility);
 
         assert_eq!(unit.position().col(), 5);
         assert_eq!(unit.position().row(), 5);
@@ -48,10 +63,20 @@ mod tests {
 
     #[test]
     fn test_move_to_insufficient_action_points() {
+        let mut action = Action::create(
+            ActionType::new(ActionTypeValue::Move),
+            UnitId::new(Uuid::new_v4().to_string()),
+            UnitTypeId::new(Uuid::new_v4().to_string()),
+            Position::new(5, 5),
+            TriggerId::new("IBIS".to_string()),
+            TriggerId::new("SHIELD".to_string()),
+            TriggerAzimuth::new(0),
+            TriggerAzimuth::new(0),
+            CurrentActionPoints::new(5),
+        );
         let mut unit = create_test_0_action_points_unit();
-        let new_position = Position::new(5, 5);
         let mut visibility = Visibility::create();
-        let result = unit.move_to(new_position, &mut visibility);
+        let result = unit.move_to(&mut action, &mut visibility);
         assert!(!result);
     }
 
@@ -60,9 +85,19 @@ mod tests {
         let mut unit = create_test_unit();
         unit.bailout();
 
-        let new_position = Position::new(5, 5);
+        let mut action = Action::create(
+            ActionType::new(ActionTypeValue::Move),
+            UnitId::new(Uuid::new_v4().to_string()),
+            UnitTypeId::new(Uuid::new_v4().to_string()),
+            Position::new(5, 5),
+            TriggerId::new("IBIS".to_string()),
+            TriggerId::new("SHIELD".to_string()),
+            TriggerAzimuth::new(0),
+            TriggerAzimuth::new(0),
+            CurrentActionPoints::new(5),
+        );
         let mut visibility = Visibility::create();
-        let result = unit.move_to(new_position, &mut visibility);
+        let result = unit.move_to(&mut action, &mut visibility);
 
         assert!(!result);
     }

--- a/game_server/rust_app/src/domain/unit_management/models/unit_type/unit_type_spec.rs
+++ b/game_server/rust_app/src/domain/unit_management/models/unit_type/unit_type_spec.rs
@@ -16,6 +16,16 @@ impl UnitTypeSpec {
     pub fn get_spec(unit_type_id: &str) -> Option<Self> {
         let specs: HashMap<&str, UnitTypeSpec> = [
             (
+                "AVERAGE_MEMBER",
+                UnitTypeSpec {
+                    unit_type_id: "AVERAGE_MEMBER".to_string(),
+                    base_attack: 5,
+                    base_defense: 5,
+                    base_avoid: 5,
+                    action_points: 14,
+                },
+            ),
+            (
                 "MIKUMO_OSAMU",
                 UnitTypeSpec {
                     unit_type_id: "MIKUMO_OSAMU".to_string(),

--- a/game_server/rust_app/src/infrastructure/dynamodb/unit_dynamodb_repository_test.rs
+++ b/game_server/rust_app/src/infrastructure/dynamodb/unit_dynamodb_repository_test.rs
@@ -3,9 +3,16 @@ mod tests {
     use crate::{
         domain::{
             player_management::models::player::player_id::player_id::PlayerId,
-            triggergame_simulator::models::game::{
-                game_id::game_id::GameId,
-                visibility::{self, Visibility},
+            triggergame_simulator::models::{
+                action::{
+                    action_type::action_type::{ActionType, ActionTypeValue},
+                    trigger_azimuth::trigger_azimuth::TriggerAzimuth,
+                    Action,
+                },
+                game::{
+                    game_id::game_id::GameId,
+                    visibility::{self, Visibility},
+                },
             },
             unit_management::{
                 models::unit::{
@@ -73,8 +80,19 @@ mod tests {
     async fn test_update_unit() {
         let mut unit = create_test_unit();
         let mut visibility = Visibility::create();
+        let mut action = Action::create(
+            ActionType::new(ActionTypeValue::Move),
+            UnitId::new(Uuid::new_v4().to_string()),
+            UnitTypeId::new(Uuid::new_v4().to_string()),
+            Position::new(7, 12),
+            TriggerId::new("IBIS".to_string()),
+            TriggerId::new("SHIELD".to_string()),
+            TriggerAzimuth::new(0),
+            TriggerAzimuth::new(0),
+            CurrentActionPoints::new(5),
+        );
         // ユニットの状態を更新
-        unit.move_to(Position::new(7, 12), &mut visibility);
+        unit.move_to(&mut action, &mut visibility);
         unit.consume_action_points(1).unwrap();
 
         // UpdateItemの成功レスポンスをモック


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記載 -->

攻撃時に使用したトリガーに設定されている行動力に基づいて行動力を消費する

## 関連Issue

- Closes #93 

## 変更内容

- 攻撃判定をパターンに分けた
- 攻撃判定を網羅したユニットテストを実装
- Actionを更新できていない不具合を修正

## 動作確認

### 確認環境

- [x] local
- [ ] dev

### 手順

1. ゲームを開始する
2. 空閑くんを防御者として千佳ちゃんに攻撃させる・移動させる

### 結果

- [x] 期待通りに動作する
- [x] 既存機能へ副作用がないことを確認した

## 影響範囲

- [x] game-client
- [x] game_server
- [ ] local-websocket-apigateway
- [ ] local-dynamodb-initialize
- [ ] local-eventbridge-scheduler
- [ ] ドキュメント

## テスト

- [x] 追加/変更した処理に対して必要なテストを実施した
- [ ] 手動確認のみ（理由を下に記載）

手動確認理由（必要時）:

## UI変更（必要時）

- スクリーンショット or 動画を添付

## レビュー観点（任意）

<!-- 特に見てほしい点があれば記載 -->

## チェックリスト

- [x] ブランチ名が規約に沿っている（`feature/*`, `fix/*`, `chore/*`, `docs/*`）
- [x] PRタイトルが規約に沿っている（`<type>: <概要> (#issue番号)`）
- [x] 1PR1目的になっている
- [x] 不要な差分（無関係な整形/リネーム等）がない
- [x] 破壊的変更がある場合、内容と移行手順を記載した

## 備考

上記はあくまで推奨ルールです。従わなくても全然いいですが、迷ったら参考にしてください。
