### PR TITLE
feat: LambdaのランタイムをAmazon Linux 2から2023に変更 (#102)

### DIFF
--- a/game_server/template.yaml
+++ b/game_server/template.yaml
@@ -28,7 +28,7 @@ Resources:
       CodeUri: ./rust_app
       FunctionName: !Sub '${TriggerGameFunctionName}-${EnvironmentName}'
       Handler: bootstrap
-      Runtime: provided.al2
+      Runtime: provided.al2023
       Architectures:
       - x86_64
       Layers:
@@ -86,11 +86,11 @@ Resources:
   WtModelLayer:
     Type: AWS::Serverless::LayerVersion
     Properties:
-      LayerName: wt-model-layer
+      LayerName: !Sub 'wt-model-layer-${EnvironmentName}'
       Description: ONNX model files for wt ai
       ContentUri: ../machine_learning/models/   # パッケージに含めるローカルフォルダ
       CompatibleRuntimes:
-        - provided.al2
+        - provided.al2023
 
   # EventBridge Scheduler のスケジュールグループ
   TriggerGameSchedulerGroup:


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記載 -->
LambdaのランタイムをAmazon Linux 2から2023に変更

## 関連Issue

- Closes #102 

## 変更内容

- Runtimeを `provided.al2` から `provided.al2023` に変更
- Lambdaレイヤー名にdevやprdをつける

## 動作確認

### 確認環境

- [x] local
- [x] dev

### 手順

1. ゲームの一連の流れを実装して不具合がないことを確認

### 結果

- [x] 期待通りに動作する
- [x] 既存機能へ副作用がないことを確認した

## 影響範囲

- [ ] game-client
- [x] game_server
- [ ] local-websocket-apigateway
- [ ] local-dynamodb-initialize
- [ ] local-eventbridge-scheduler
- [ ] ドキュメント

## テスト

- [ ] 追加/変更した処理に対して必要なテストを実施した
- [x] 手動確認のみ（理由を下に記載）

手動確認理由（必要時）:

## UI変更（必要時）

- スクリーンショット or 動画を添付

## レビュー観点（任意）

<!-- 特に見てほしい点があれば記載 -->

## チェックリスト

- [x] ブランチ名が規約に沿っている（`feature/*`, `fix/*`, `chore/*`, `docs/*`）
- [x] PRタイトルが規約に沿っている（`<type>: <概要> (#issue番号)`）
- [x] 1PR1目的になっている
- [x] 不要な差分（無関係な整形/リネーム等）がない
- [x] 破壊的変更がある場合、内容と移行手順を記載した

## 備考

上記はあくまで推奨ルールです。従わなくても全然いいですが、迷ったら参考にしてください。
