### PR TITLE
feat: 動きの設定完了後にレイヤー表示

### DIFF
--- a/game-client/components/dialogs/Loading/index.stories.tsx
+++ b/game-client/components/dialogs/Loading/index.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import LoadingDialog from ".";
+
+const meta: Meta<typeof LoadingDialog> = {
+  title: "Dialogs/LoadingDialog",
+  component: LoadingDialog,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    message: "Loading...",
+    isOpen: true,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LoadingDialog>;
+
+export const Normal: Story = {
+  render: (args) => {
+    return (
+      <div className="min-h-screen bg-[#04070d]">
+        <LoadingDialog {...args} />
+      </div>
+    );
+  },
+};

--- a/game-client/components/dialogs/Loading/index.tsx
+++ b/game-client/components/dialogs/Loading/index.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import NormalFullDialog from "../NormalFullDialog";
+
+/**
+ * LoadingDialog コンポーネントの props。
+ */
+interface LoadingDialogProps {
+  /** 六角形インジケータの下に表示するメッセージ。 */
+  message: string;
+  /** ダイアログ表示状態。未指定時は表示する。 */
+  isOpen?: boolean;
+}
+
+/**
+ * SVG 上の座標点。
+ */
+interface Point {
+  x: number;
+  y: number;
+}
+
+/** アクティブな辺の発光色。 */
+const HIGHLIGHT_COLOR = "#00e5ff";
+/** 非アクティブな辺の発光色。 */
+const BASE_COLOR = "#ffffff";
+/** 発光する辺を次の辺へ移動する間隔 (ms)。 */
+const EDGE_MOVE_INTERVAL_MS = 1000;
+
+/**
+ * 六角形の各頂点座標を生成する。
+ *
+ * @param centerX 六角形中心の X 座標。
+ * @param centerY 六角形中心の Y 座標。
+ * @param radius 六角形の外接円半径。
+ * @returns 六角形の頂点配列。
+ */
+const createHexPoints = (centerX: number, centerY: number, radius: number): Point[] => {
+  return Array.from({ length: 6 }, (_, index) => {
+    const angle = (Math.PI / 180) * (60 * index - 90);
+    return {
+      x: centerX + radius * Math.cos(angle),
+      y: centerY + radius * Math.sin(angle),
+    };
+  });
+};
+
+/**
+ * 1 辺の両端を少し内側へ縮め、頂点がつながらない線分を作る。
+ *
+ * @param from 辺の始点。
+ * @param to 辺の終点。
+ * @param trimRatio 辺の両端を削る比率。
+ * @returns 描画用の短縮済み線分座標。
+ */
+const getTrimmedEdge = (from: Point, to: Point, trimRatio: number) => {
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+
+  return {
+    x1: from.x + dx * trimRatio,
+    y1: from.y + dy * trimRatio,
+    x2: to.x - dx * trimRatio,
+    y2: to.y - dy * trimRatio,
+  };
+};
+
+/**
+ * ローディング用の全画面ダイアログ。
+ *
+ * @param props 表示メッセージと開閉状態。
+ * @returns 発光する六角形インジケータを表示するダイアログ。
+ */
+export default function LoadingDialog({ message, isOpen = true }: LoadingDialogProps) {
+  /** dialog 要素への参照。 */
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  /** 現在アクティブな辺インデックス。 */
+  const [activeEdgeIndex, setActiveEdgeIndex] = useState(0);
+
+  /** 六角形の 6 辺座標を初回レンダリング時に生成する。 */
+  const edges = useMemo(() => {
+    const points = createHexPoints(60, 60, 42);
+    return points.map((point, index) => {
+      const nextPoint = points[(index + 1) % points.length];
+      return getTrimmedEdge(point, nextPoint, 0.12);
+    });
+  }, []);
+
+  /** isOpen に応じて dialog の open/close を同期する。 */
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) {
+      return;
+    }
+
+    if (isOpen && !dialog.open) {
+      dialog.showModal();
+    }
+
+    if (!isOpen && dialog.open) {
+      dialog.close();
+    }
+  }, [isOpen]);
+
+  /** 表示中のみ 1 秒ごとにアクティブ辺を進める。 */
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const timerId = window.setInterval(() => {
+      setActiveEdgeIndex((prev) => (prev + 1) % 6);
+    }, EDGE_MOVE_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(timerId);
+    };
+  }, [isOpen]);
+
+  return (
+    <NormalFullDialog ref={dialogRef}>
+      <div className="flex h-full w-full items-center justify-center px-6">
+        <div className="flex flex-col items-center gap-2">
+          <svg
+            width="160"
+            height="160"
+            viewBox="0 0 120 120"
+            fill="none"
+            aria-hidden="true"
+          >
+            {edges.map((edge, index) => {
+              const isActive = index === activeEdgeIndex;
+              const strokeColor = isActive ? HIGHLIGHT_COLOR : BASE_COLOR;
+
+              return (
+                <line
+                  key={`hex-edge-${index}`}
+                  x1={edge.x1}
+                  y1={edge.y1}
+                  x2={edge.x2}
+                  y2={edge.y2}
+                  stroke={strokeColor}
+                  strokeWidth={isActive ? 4 : 3}
+                  strokeLinecap="round"
+                  style={{
+                    filter: isActive
+                      ? "drop-shadow(0 0 8px #00e5ff) drop-shadow(0 0 14px #00e5ff)"
+                      : "drop-shadow(0 0 6px rgba(255,255,255,0.95)) drop-shadow(0 0 12px rgba(255,255,255,0.45))",
+                  }}
+                />
+              );
+            })}
+          </svg>
+
+          <p className="text-center text-lg text-white sm:text-xl font-michroma">{message}</p>
+        </div>
+      </div>
+    </NormalFullDialog>
+  );
+}

--- a/game-client/game-logics/GameGrid.tsx
+++ b/game-client/game-logics/GameGrid.tsx
@@ -12,6 +12,7 @@ import { Turn } from "./models/Turn";
 import { GameResult } from "@/types/GameTypes";
 import MotionLabDialog, { MotionLabDialogHandle } from "@/components/dialogs/MotionMode/MotionLabDialog";
 import MotionExecuteDialog, { MotionExecuteDialogHandle } from "@/components/dialogs/MotionMode/MotionExecuteDialog";
+import LoadingDialog from "@/components/dialogs/Loading";
 import TurnStateMotionLabPanel from "@/components/panels/TurnStatePanel/MotionLab";
 import TurnStateMotionExecutePanel from "@/components/panels/TurnStatePanel/MotionExecute";
 import { MAX_TURN } from "./config/game-config";
@@ -51,6 +52,7 @@ const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnit
   const [gameMode, setGameMode] = useState<"lab" | "execute">("lab");
   const [motionLabEndTimeState, setMotionLabEndTimeState] = useState<Date>(motionLabEndTime);
   const [motionExecuteEndTimeState, setMotionExecuteEndTimeState] = useState<Date>(motionLabEndTime);
+  const [isSendingMotionLabTurn, setIsSendingMotionLabTurn] = useState(false);
   const motionLabDialogRef = useRef<MotionLabDialogHandle>(null);
   const motionExecuteDialogRef = useRef<MotionExecuteDialogHandle>(null);
 
@@ -81,6 +83,7 @@ const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnit
   const handleTurnExecution = (steps: Step[]) => {
     console.log("Phaserからターン情報を受け取りました:", steps, isConnected, playerId, gameId);
     if (isConnected && playerId && gameId && gameResult === "InProgress") {
+      setIsSendingMotionLabTurn(true);
       const messageData = {
         action: "turnExecution" as const,
         playerId,
@@ -115,6 +118,8 @@ const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnit
     /** ターンの実行 */
     const handleTurnResultSubmitted = (data: WebSocketResponseType) => {
       if (data.action === "turnExecutionResult") {
+        setIsSendingMotionLabTurn(false);
+
         let activeScene: GridCellsScene | null = null;
         if (gameRef.current) {
           try {
@@ -142,6 +147,7 @@ const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnit
     /** 対戦終了結果の処理 */
     const handleCancelMatchingResult = (data: WebSocketResponseType) => {
       if (data.action === "cancelMatchingResult") {
+        setIsSendingMotionLabTurn(false);
         console.log("対戦終了結果を受信:", data);
         console.log("対戦が正常に終了されました。ホーム画面に戻ります。");
         router.push("/");
@@ -268,6 +274,10 @@ const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnit
    * 動きの設定を途中送信する
    */
   const handleSendMotionLabTurn = () => {
+    if (isSendingMotionLabTurn) {
+      return;
+    }
+
     let activeScene: GridCellsScene | null = null;
     if (gameRef.current) {
       try {
@@ -282,6 +292,8 @@ const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnit
       console.warn("GridSceneが未初期化のためturnExecutionResultを処理できません");
       return;
     }
+
+    setIsSendingMotionLabTurn(true);
     targetScene.sendServerTurnManual();
   };
 
@@ -292,7 +304,13 @@ const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnit
 
       {/* ゲームモード表示 */}
       <div className="absolute top-2 right-2 p-2 z-50 flex flex-row items-start gap-2">
-        <SkyOutlineButton href="#" onClick={handleSendMotionLabTurn} className="text-sm text-center">動きの設定を送信<br />MotionLab Ready !</SkyOutlineButton>
+        <SkyOutlineButton
+          href="#"
+          onClick={handleSendMotionLabTurn}
+          className={`text-sm text-center ${isSendingMotionLabTurn ? "pointer-events-none opacity-50" : ""}`}
+        >
+          動きの設定を送信<br />MotionLab Ready !
+        </SkyOutlineButton>
         {gameMode === "lab" ? (
           <TurnStateMotionLabPanel turn={currentTurn} endtime={motionLabEndTimeState} maxTurn={MAX_TURN} />
         ) : (
@@ -310,6 +328,7 @@ const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnit
       {/* 動きの設定とユニットの行動のダイアログ表示 */}
       <MotionLabDialog ref={motionLabDialogRef} turn={currentTurn}></MotionLabDialog>
       <MotionExecuteDialog ref={motionExecuteDialogRef} turn={currentTurn}></MotionExecuteDialog>
+      <LoadingDialog message="Waiting..." isOpen={isSendingMotionLabTurn} />
     </div>
   );
 };


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記載 -->

## 関連Issue

- Closes #101 

## 変更内容

- 動きの設定完了後にローディングのダイアログを表示
- ダイアログの確認用storybookを追加

## 動作確認

### 確認環境

- [x] local
- [ ] dev

### 手順

1. 
2. 
3. 

### 結果

- [ ] 期待通りに動作する
- [ ] 既存機能へ副作用がないことを確認した

## 影響範囲

- [ ] game-client
- [ ] game_server
- [ ] local-websocket-apigateway
- [ ] local-dynamodb-initialize
- [ ] local-eventbridge-scheduler
- [ ] ドキュメント

## テスト

- [ ] 追加/変更した処理に対して必要なテストを実施した
- [ ] 手動確認のみ（理由を下に記載）

手動確認理由（必要時）:

## UI変更（必要時）

- スクリーンショット or 動画を添付

## レビュー観点（任意）

<!-- 特に見てほしい点があれば記載 -->

## チェックリスト

- [ ] ブランチ名が規約に沿っている（`feature/*`, `fix/*`, `chore/*`, `docs/*`）
- [ ] PRタイトルが規約に沿っている（`<type>: <概要> (#issue番号)`）
- [ ] 1PR1目的になっている
- [ ] 不要な差分（無関係な整形/リネーム等）がない
- [ ] 破壊的変更がある場合、内容と移行手順を記載した

## 備考

上記はあくまで推奨ルールです。従わなくても全然いいですが、迷ったら参考にしてください。
