### PR TITLE
fix: ユニットの行動モード中に動きの設定を送信ボタンを押せ無いようにする (#119)

### DIFF
--- a/game-client/game-logics/GameGrid.tsx
+++ b/game-client/game-logics/GameGrid.tsx
@@ -55,6 +55,7 @@ const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnit
   const [isSendingMotionLabTurn, setIsSendingMotionLabTurn] = useState(false);
   const motionLabDialogRef = useRef<MotionLabDialogHandle>(null);
   const motionExecuteDialogRef = useRef<MotionExecuteDialogHandle>(null);
+  const isMotionLabTurnSendDisabled = isSendingMotionLabTurn || gameMode !== "lab";
 
   // WebSocketコンテキストを使用
   const {
@@ -274,7 +275,7 @@ const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnit
    * 動きの設定を途中送信する
    */
   const handleSendMotionLabTurn = () => {
-    if (isSendingMotionLabTurn) {
+    if (isMotionLabTurnSendDisabled) {
       return;
     }
 
@@ -307,7 +308,7 @@ const GameGrid: React.FC<GameGridProps> = ({ currentTurn, friendUnits, enemyUnit
         <SkyOutlineButton
           href="#"
           onClick={handleSendMotionLabTurn}
-          className={`text-sm text-center ${isSendingMotionLabTurn ? "pointer-events-none opacity-50" : ""}`}
+          className={`text-sm text-center ${isMotionLabTurnSendDisabled ? "pointer-events-none opacity-50" : ""}`}
         >
           動きの設定を送信<br />MotionLab Ready !
         </SkyOutlineButton>


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記載 -->

## 関連Issue

- Closes #119 

## 変更内容

- ユニットの行動モード中は動きの設定を送信ボタンを非活性にする

## 動作確認

### 確認環境

- [x] local
- [ ] dev

### 手順

1. ユニットの行動モード開始
2. 動きの設定を送信ボタンを押す
3. 非活性になっていることを確認する

### 結果

- [x] 期待通りに動作する
- [x] 既存機能へ副作用がないことを確認した

## 影響範囲

- [x] game-client
- [ ] game_server
- [ ] local-websocket-apigateway
- [ ] local-dynamodb-initialize
- [ ] local-eventbridge-scheduler
- [ ] ドキュメント

## テスト

- [x] 追加/変更した処理に対して必要なテストを実施した
- [ ] 手動確認のみ（理由を下に記載）

手動確認理由（必要時）:

## UI変更（必要時）

- スクリーンショット or 動画を添付

## レビュー観点（任意）

<!-- 特に見てほしい点があれば記載 -->

## チェックリスト

- [x] ブランチ名が規約に沿っている（`feature/*`, `fix/*`, `chore/*`, `docs/*`）
- [x] PRタイトルが規約に沿っている（`<type>: <概要> (#issue番号)`）
- [x] 1PR1目的になっている
- [x] 不要な差分（無関係な整形/リネーム等）がない
- [x] 破壊的変更がある場合、内容と移行手順を記載した

## 備考

上記はあくまで推奨ルールです。従わなくても全然いいですが、迷ったら参考にしてください。
